### PR TITLE
Removing dependencies on FESOM for REcoM internal subroutines

### DIFF
--- a/recom_atbox.F90
+++ b/recom_atbox.F90
@@ -26,7 +26,7 @@
 
 !     Globally integrated air-sea CO2 flux (mol / s)
       total_co2flux    = 0.
-      call integrate_nod_2d_recom(0.001 * GloCO2flux_seaicemask   , total_CO2flux,  partit,  mesh)
+      call integrate_nod_2d_recom(0.001 * GloCO2flux_seaicemask, total_CO2flux, partit%MPI_COMM_FESOM, partit%myDim_nod2D, partit%eDim_nod2D, mesh%ulevels_nod2D, mesh%areasvol)
 
 !     Atmospheric carbon budget (mol)
 !     mass of the dry atmosphere = 5.1352e18 kg (Trenberth & Smith 2005, doi:10.1175/JCLI-3299.1)
@@ -43,7 +43,7 @@
 
 !       Globally integrated air-sea 13CO2 flux (mol / s)
         total_co2flux_13 = 0.
-        call integrate_nod_2d_recom(0.001 * GloCO2flux_seaicemask_13, total_co2flux_13, partit, mesh)
+        call integrate_nod_2d_recom(0.001 * GloCO2flux_seaicemask_13, total_co2flux_13, partit%MPI_COMM_FESOM, partit%myDim_nod2D, partit%eDim_nod2D, mesh%ulevels_nod2D, mesh%areasvol)
 
 !       Atmospheric carbon-13 budget (mol)
 !       mol_co2atm_13 = mol_co2atm_13 - total_co2flux_13 * dt 
@@ -54,7 +54,7 @@
 
         if (ciso_14) then
           total_co2flux_14   = 0.  ! globally integrated air-sea 14CO2 flux (mol / s)
-          call integrate_nod_2d_recom(0.001 * GloCO2flux_seaicemask_14, total_co2flux_14, partit, mesh)
+          call integrate_nod_2d_recom(0.001 * GloCO2flux_seaicemask_14, total_co2flux_14, partit%MPI_COMM_FESOM, partit%myDim_nod2D, partit%eDim_nod2D, mesh%ulevels_nod2D, mesh%areasvol)
 !         Atmospheric radiocarbon budget in mol:
 !         mol_co2atm_14 = mol_co2atm_14  + dt * (cosmic_14(1) - mol_co2atm_14 * lambda_14 - total_co2flux_14)
 !                       = (mol_co2atm_14  + dt * (cosmic_14(1) - total_co2flux_14)) / (1 + lambda_14 * dt)

--- a/recom_atbox.F90
+++ b/recom_atbox.F90
@@ -7,8 +7,8 @@
       use recom_config
       use recom_ciso
 
-      use mod_mesh, only: t_mesh, sparse_matrix
-      USE MOD_PARTIT, only: t_partit, com_struct
+      use mod_mesh, only: t_mesh
+      USE MOD_PARTIT, only: t_partit
 
       use g_config, only: dt
       use g_forcing_arrays, only: wp
@@ -22,11 +22,6 @@
       real(kind=WP), parameter          :: mol_allatm = 1.7726e20  ! atmospheric inventory of all compounds (mol)
       type(t_partit), intent(inout), target :: partit
       type(t_mesh)  , intent(inout), target :: mesh
-
-#include "../associate_part_def.h"
-#include "../associate_mesh_def.h"
-#include "../associate_part_ass.h"
-#include "../associate_mesh_ass.h"
 
 !     Globally integrated air-sea CO2 flux (mol / s)
       total_co2flux    = 0.

--- a/recom_atbox.F90
+++ b/recom_atbox.F90
@@ -1,4 +1,16 @@
-    subroutine recom_atbox(partit, mesh)
+module recom_atbox_module
+    interface
+        subroutine recom_atbox(MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D, ulevels_nod2D, areasvol)
+            use g_config, only: wp
+
+            integer,       intent(in) :: MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D
+            integer,       intent(in), dimension(:)   :: ulevels_nod2D
+            real(kind=WP), intent(in), dimension(:,:) :: areasvol
+        end subroutine
+    end interface
+end module recom_atbox_module
+
+    subroutine recom_atbox(MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D, ulevels_nod2D, areasvol)
 !     Simple 0-d box model to calculate the temporal evolution of atmospheric CO2.
 !     Initially the box model was part of module recom_ciso. Now it can be run also 
 !     without carbon isotopes (ciso==.false.)
@@ -6,27 +18,25 @@
       use REcoM_GloVar
       use recom_config
       use recom_ciso
-
-      use mod_mesh, only: t_mesh
-      USE MOD_PARTIT, only: t_partit
       use recom_extra, only: integrate_nod_2d_recom
-
-      use g_config, only: dt
-      use g_forcing_arrays, only: wp
-      use g_support, only: integrate_nod
+      use g_config, only: dt, wp
       
       implicit none
-      integer                           :: n, elem, elnodes(3),n1
-      real(kind=WP)                     :: total_co2flux,    &     ! (mol / s) 
-                                           total_co2flux_13, &     ! (mol / s) carbon-13
-                                           total_co2flux_14        ! (mol / s) radiocarbon
-      real(kind=WP), parameter          :: mol_allatm = 1.7726e20  ! atmospheric inventory of all compounds (mol)
-      type(t_partit), intent(inout), target :: partit
-      type(t_mesh)  , intent(inout), target :: mesh
+
+      integer,       intent(in) :: MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D
+      integer,       intent(in), dimension(:)   :: ulevels_nod2D
+      real(kind=WP), intent(in), dimension(:,:) :: areasvol
+
+      integer                  :: n, elem, elnodes(3),n1
+      real(kind=WP), parameter :: mol_allatm = 1.7726e20  ! atmospheric inventory of all compounds (mol)
+      real(kind=WP)            :: total_co2flux,    &     ! (mol / s)
+                                  total_co2flux_13, &     ! (mol / s) carbon-13
+                                  total_co2flux_14        ! (mol / s) radiocarbon
 
 !     Globally integrated air-sea CO2 flux (mol / s)
-      total_co2flux    = 0.
-      call integrate_nod_2d_recom(0.001 * GloCO2flux_seaicemask, total_CO2flux, partit%MPI_COMM_FESOM, partit%myDim_nod2D, partit%eDim_nod2D, mesh%ulevels_nod2D, mesh%areasvol)
+      total_co2flux = 0.
+      call integrate_nod_2d_recom(0.001 * GloCO2flux_seaicemask, total_CO2flux, MPI_COMM_FESOM, &
+                                  myDim_nod2D, eDim_nod2D, ulevels_nod2D, areasvol)
 
 !     Atmospheric carbon budget (mol)
 !     mass of the dry atmosphere = 5.1352e18 kg (Trenberth & Smith 2005, doi:10.1175/JCLI-3299.1)
@@ -35,15 +45,17 @@
 !     mol_co2atm    = mol_co2atm    - total_co2flux    * dt 
 !     Atmospheric mixing ratios in ppm
 !     x_co2atm(1)    = mol_co2atm    / mol_allatm * 1.e6 ! ppm
-      x_co2atm(1)    = x_co2atm(1)    - total_co2flux    / mol_allatm * dt * 1.e6
-      x_co2atm       = x_co2atm(1)
+      x_co2atm(1) = x_co2atm(1) - total_co2flux / mol_allatm * dt * 1.e6
+      x_co2atm    = x_co2atm(1)
 
       if (ciso) then
 !       Consider 13CO2 (and maybe also 14CO2)
 
 !       Globally integrated air-sea 13CO2 flux (mol / s)
         total_co2flux_13 = 0.
-        call integrate_nod_2d_recom(0.001 * GloCO2flux_seaicemask_13, total_co2flux_13, partit%MPI_COMM_FESOM, partit%myDim_nod2D, partit%eDim_nod2D, mesh%ulevels_nod2D, mesh%areasvol)
+        call integrate_nod_2d_recom(0.001 * GloCO2flux_seaicemask_13, total_co2flux_13,     &
+                                    MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D, ulevels_nod2D, &
+                                    areasvol)
 
 !       Atmospheric carbon-13 budget (mol)
 !       mol_co2atm_13 = mol_co2atm_13 - total_co2flux_13 * dt 
@@ -53,8 +65,10 @@
         x_co2atm_13    = x_co2atm_13(1)
 
         if (ciso_14) then
-          total_co2flux_14   = 0.  ! globally integrated air-sea 14CO2 flux (mol / s)
-          call integrate_nod_2d_recom(0.001 * GloCO2flux_seaicemask_14, total_co2flux_14, partit%MPI_COMM_FESOM, partit%myDim_nod2D, partit%eDim_nod2D, mesh%ulevels_nod2D, mesh%areasvol)
+          total_co2flux_14 = 0.  ! globally integrated air-sea 14CO2 flux (mol / s)
+          call integrate_nod_2d_recom(0.001 * GloCO2flux_seaicemask_14, total_co2flux_14,     &
+                                      MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D, ulevels_nod2D, &
+                                      areasvol)
 !         Atmospheric radiocarbon budget in mol:
 !         mol_co2atm_14 = mol_co2atm_14  + dt * (cosmic_14(1) - mol_co2atm_14 * lambda_14 - total_co2flux_14)
 !                       = (mol_co2atm_14  + dt * (cosmic_14(1) - total_co2flux_14)) / (1 + lambda_14 * dt)

--- a/recom_atbox.F90
+++ b/recom_atbox.F90
@@ -9,6 +9,7 @@
 
       use mod_mesh, only: t_mesh
       USE MOD_PARTIT, only: t_partit
+      use recom_extra, only: integrate_nod_2d_recom
 
       use g_config, only: dt
       use g_forcing_arrays, only: wp
@@ -25,7 +26,7 @@
 
 !     Globally integrated air-sea CO2 flux (mol / s)
       total_co2flux    = 0.
-      call integrate_nod(0.001 * GloCO2flux_seaicemask   , total_CO2flux,  partit,  mesh)
+      call integrate_nod_2d_recom(0.001 * GloCO2flux_seaicemask   , total_CO2flux,  partit,  mesh)
 
 !     Atmospheric carbon budget (mol)
 !     mass of the dry atmosphere = 5.1352e18 kg (Trenberth & Smith 2005, doi:10.1175/JCLI-3299.1)
@@ -42,7 +43,7 @@
 
 !       Globally integrated air-sea 13CO2 flux (mol / s)
         total_co2flux_13 = 0.
-        call integrate_nod(0.001 * GloCO2flux_seaicemask_13, total_co2flux_13, partit, mesh)
+        call integrate_nod_2d_recom(0.001 * GloCO2flux_seaicemask_13, total_co2flux_13, partit, mesh)
 
 !       Atmospheric carbon-13 budget (mol)
 !       mol_co2atm_13 = mol_co2atm_13 - total_co2flux_13 * dt 
@@ -53,7 +54,7 @@
 
         if (ciso_14) then
           total_co2flux_14   = 0.  ! globally integrated air-sea 14CO2 flux (mol / s)
-          call integrate_nod(0.001 * GloCO2flux_seaicemask_14, total_co2flux_14, partit, mesh)
+          call integrate_nod_2d_recom(0.001 * GloCO2flux_seaicemask_14, total_co2flux_14, partit, mesh)
 !         Atmospheric radiocarbon budget in mol:
 !         mol_co2atm_14 = mol_co2atm_14  + dt * (cosmic_14(1) - mol_co2atm_14 * lambda_14 - total_co2flux_14)
 !                       = (mol_co2atm_14  + dt * (cosmic_14(1) - total_co2flux_14)) / (1 + lambda_14 * dt)

--- a/recom_atbox.F90
+++ b/recom_atbox.F90
@@ -3,25 +3,16 @@
 !     Initially the box model was part of module recom_ciso. Now it can be run also 
 !     without carbon isotopes (ciso==.false.)
 !     mbutzin, 2021-07-08
-
-!     Settings are copied from subroutine bio_fluxes,
-!     some of the following modules may be unnecessary here
-!     use REcoM_declarations
-!     use REcoM_LocVar
       use REcoM_GloVar
       use recom_config
       use recom_ciso
 
-    use mod_mesh
-    USE MOD_PARTIT
-    USE MOD_PARSUP
+      use mod_mesh, only: t_mesh, sparse_matrix
+      USE MOD_PARTIT, only: t_partit, com_struct
 
-    use g_config
-    use o_arrays
-    use g_comm_auto
-    use g_forcing_arrays
-    use g_support
-
+      use g_config, only: dt
+      use g_forcing_arrays, only: wp
+      use g_support, only: integrate_nod
       
       implicit none
       integer                           :: n, elem, elnodes(3),n1
@@ -29,8 +20,8 @@
                                            total_co2flux_13, &     ! (mol / s) carbon-13
                                            total_co2flux_14        ! (mol / s) radiocarbon
       real(kind=WP), parameter          :: mol_allatm = 1.7726e20  ! atmospheric inventory of all compounds (mol)
-    type(t_partit), intent(inout), target :: partit
-    type(t_mesh)  , intent(inout), target :: mesh
+      type(t_partit), intent(inout), target :: partit
+      type(t_mesh)  , intent(inout), target :: mesh
 
 #include "../associate_part_def.h"
 #include "../associate_mesh_def.h"
@@ -89,4 +80,3 @@
 
       return
     end subroutine recom_atbox
-

--- a/recom_extra.F90
+++ b/recom_extra.F90
@@ -17,11 +17,10 @@ module recom_extra
             real(kind=8), dimension(mesh%nl-1), intent(out)  :: recipthick  ! [1/m] Reciprocal thickness
         end subroutine Depth_calculations
 
-        subroutine Cobeta(partit, mesh)
-            use mod_mesh, only: t_mesh
-            use MOD_PARTIT, only: t_partit
-            type(t_partit), intent(inout),   target          :: partit
-            type(t_mesh)  , intent(inout),   target          :: mesh
+        subroutine Cobeta(daynew, ndpyr, myDim_nod2D, eDim_nod2D, geo_coord_nod2D)
+            use o_PARAM, only: wp
+            integer, intent(in)                       :: daynew, ndpyr, myDim_nod2D, eDim_nod2D
+            real(kind=WP), intent(in), dimension(:,:) :: geo_coord_nod2D
         end subroutine Cobeta
 
         subroutine krill_resp(n, daynew, myDim_nod2D, eDim_nod2D, geo_coord_nod2D)
@@ -125,18 +124,11 @@ end subroutine Depth_calculations
 !===============================================================================
 ! Subroutine for calculating cos(AngleOfIncidence)
 !===============================================================================
-subroutine Cobeta(partit, mesh)
+subroutine Cobeta(daynew, ndpyr, myDim_nod2D, eDim_nod2D, geo_coord_nod2D)
     use REcoM_GloVar
-    use g_clock, only: daynew, ndpyr
-    use mod_mesh, only: t_mesh
-    use MOD_PARTIT, only: t_partit
     use o_PARAM, only: wp, pi
 
     implicit none
-
-    ! Input parameters
-    type(t_partit), intent(inout),   target          :: partit
-    type(t_mesh)  , intent(inout),   target          :: mesh
 
     ! Local variables
     real(kind=8)                                     :: yearfrac              ! Fraction of year [0 1]
@@ -148,12 +140,8 @@ subroutine Cobeta(partit, mesh)
     ! Constants
     real(kind=8), parameter                          :: nWater        = 1.33  ! Refractive indices of water
 
-    integer, pointer                       :: myDim_nod2D, eDim_nod2D
-    real(kind=WP), dimension(:,:), pointer :: geo_coord_nod2D
-
-    myDim_nod2D                                   => partit%myDim_nod2D
-    eDim_nod2D                                    => partit%eDim_nod2D
-    geo_coord_nod2D(1:2,1:myDim_nod2D+eDim_nod2D) => mesh%geo_coord_nod2D(:,:)
+    integer, intent(in)                       :: daynew, ndpyr, myDim_nod2D, eDim_nod2D
+    real(kind=WP), intent(in), dimension(:,:) :: geo_coord_nod2D
 
 !! find day (****NOTE for year starting in winter*****)  
 !! Paltridge, G. W. and C. M. R. Platt, Radiative Processes 

--- a/recom_extra.F90
+++ b/recom_extra.F90
@@ -94,12 +94,10 @@ end subroutine Depth_calculations
 !===============================================================================
 subroutine Cobeta(partit, mesh)
     use REcoM_GloVar
-    use g_clock
-    use mod_mesh
-    use MOD_PARTIT
-    use MOD_PARSUP
-    use o_PARAM
-    use g_comm_auto
+    use g_clock, only: daynew, ndpyr
+    use mod_mesh, only: t_mesh, sparse_matrix
+    use MOD_PARTIT, only: t_partit, com_struct
+    use o_PARAM, only: wp, pi
 
     implicit none
   	

--- a/recom_extra.F90
+++ b/recom_extra.F90
@@ -20,20 +20,15 @@ module recom_extra
         subroutine Cobeta(partit, mesh)
             use mod_mesh, only: t_mesh
             use MOD_PARTIT, only: t_partit
-
-            ! Input parameters
             type(t_partit), intent(inout),   target          :: partit
             type(t_mesh)  , intent(inout),   target          :: mesh
         end subroutine Cobeta
 
-        subroutine krill_resp(n, partit, mesh)
-            use mod_mesh, only: t_mesh
-            use MOD_PARTIT, only: t_partit
-
-            ! Input parameters
-            integer                                          :: n
-            type(t_partit), intent(inout),   target          :: partit
-            type(t_mesh)  , intent(inout),   target          :: mesh
+        subroutine krill_resp(n, daynew, myDim_nod2D, eDim_nod2D, geo_coord_nod2D)
+            use o_PARAM, only: wp
+            integer, intent(in)                       :: n, daynew
+            integer, intent(in)                       :: myDim_nod2D, eDim_nod2D
+            real(kind=WP), intent(in), dimension(:,:) :: geo_coord_nod2D
         end subroutine krill_resp
     end interface
 end module recom_extra
@@ -190,29 +185,19 @@ end subroutine Cobeta
 !================================================================================
 ! Calculating second zooplankton respiration rates
 !================================================================================
- subroutine krill_resp(n, partit, mesh)
+subroutine krill_resp(n, daynew, myDim_nod2D, eDim_nod2D, geo_coord_nod2D)
     use REcoM_declarations
     use REcoM_LocVar
     use REcoM_GloVar
-    use mod_mesh, only: t_mesh
-    use MOD_PARTIT, only: t_partit
-    use g_clock, only: daynew
     use o_PARAM, only: wp
 
     implicit none
 
     ! Input parameters
-    integer                                          :: n
-    type(t_partit), intent(inout),   target          :: partit
-    type(t_mesh)  , intent(inout),   target          :: mesh
+    integer, intent(in)                       :: n, daynew
+    integer, intent(in)                       :: myDim_nod2D, eDim_nod2D
+    real(kind=WP), intent(in), dimension(:,:) :: geo_coord_nod2D
 
-    integer, pointer                       :: myDim_nod2D, eDim_nod2D
-    real(kind=WP), dimension(:,:), pointer :: geo_coord_nod2D
-
-    myDim_nod2D                                   => partit%myDim_nod2D
-    eDim_nod2D                                    => partit%eDim_nod2D
-    geo_coord_nod2D(1:2,1:myDim_nod2D+eDim_nod2D) => mesh%geo_coord_nod2D(:,:)
- 
    ! Values from FESOM                                                                                                 
 
    if (geo_coord_nod2D(2,n)<0.0_WP) then  !SH

--- a/recom_extra.F90
+++ b/recom_extra.F90
@@ -156,12 +156,10 @@ end subroutine Cobeta
     use REcoM_declarations
     use REcoM_LocVar
     use REcoM_GloVar
-    use g_clock
-    use o_PARAM
-    use mod_mesh
-    use MOD_PARTIT
-    use MOD_PARSUP
-    use g_comm_auto
+    use mod_mesh, only: t_mesh, sparse_matrix
+    use MOD_PARTIT, only: t_partit, com_struct
+    use g_clock, only: daynew
+    use o_PARAM, only: wp
 
     implicit none
 

--- a/recom_extra.F90
+++ b/recom_extra.F90
@@ -3,8 +3,8 @@
 !===============================================================================
 subroutine Depth_calculations(n, nn, wf, zf, thick, recipthick, partit, mesh)
     use recom_config
-    use mod_mesh, only: t_mesh, sparse_matrix
-    use MOD_PARTIT, only: t_partit, com_struct
+    use mod_mesh, only: t_mesh
+    use MOD_PARTIT, only: t_partit
     use g_clock, only: wp
 
     implicit none
@@ -24,10 +24,15 @@ subroutine Depth_calculations(n, nn, wf, zf, thick, recipthick, partit, mesh)
     ! Local variables
     integer                                          :: k           ! Layer index
 
-#include "../associate_part_def.h"
-#include "../associate_mesh_def.h"
-#include "../associate_part_ass.h"
-#include "../associate_mesh_ass.h"
+    integer, pointer                       :: myDim_nod2D, eDim_nod2D
+    real(kind=WP), dimension(:,:), pointer :: hnode
+    real(kind=WP), dimension(:,:), pointer :: zbar_3d_n
+
+    myDim_nod2D                                    => partit%myDim_nod2D
+    eDim_nod2D                                     => partit%eDim_nod2D
+    hnode(1:mesh%nl-1, 1:myDim_nod2D+eDim_nod2D)   => mesh%hnode(:,:)
+    zbar_3d_n(1:mesh%nl, 1:myDim_nod2D+eDim_nod2D) => mesh%zbar_3d_n(:,:)
+
 ! ======================================================================================
 !! zbar(nl) allocate the array for storing the standard depths (depth of layers)
 !! zbar is negative 

--- a/recom_extra.F90
+++ b/recom_extra.F90
@@ -154,8 +154,8 @@ end subroutine Cobeta
     use REcoM_declarations
     use REcoM_LocVar
     use REcoM_GloVar
-    use mod_mesh, only: t_mesh, sparse_matrix
-    use MOD_PARTIT, only: t_partit, com_struct
+    use mod_mesh, only: t_mesh
+    use MOD_PARTIT, only: t_partit
     use g_clock, only: daynew
     use o_PARAM, only: wp
 
@@ -166,10 +166,12 @@ end subroutine Cobeta
     type(t_partit), intent(inout),   target          :: partit
     type(t_mesh)  , intent(inout),   target          :: mesh
 
-#include "../associate_part_def.h"
-#include "../associate_mesh_def.h"
-#include "../associate_part_ass.h"
-#include "../associate_mesh_ass.h"
+    integer, pointer                       :: myDim_nod2D, eDim_nod2D
+    real(kind=WP), dimension(:,:), pointer :: geo_coord_nod2D
+
+    myDim_nod2D                                   => partit%myDim_nod2D
+    eDim_nod2D                                    => partit%eDim_nod2D
+    geo_coord_nod2D(1:2,1:myDim_nod2D+eDim_nod2D) => mesh%geo_coord_nod2D(:,:)
  
    ! Values from FESOM                                                                                                 
 

--- a/recom_extra.F90
+++ b/recom_extra.F90
@@ -93,12 +93,12 @@ end subroutine Depth_calculations
 subroutine Cobeta(partit, mesh)
     use REcoM_GloVar
     use g_clock, only: daynew, ndpyr
-    use mod_mesh, only: t_mesh, sparse_matrix
-    use MOD_PARTIT, only: t_partit, com_struct
+    use mod_mesh, only: t_mesh
+    use MOD_PARTIT, only: t_partit
     use o_PARAM, only: wp, pi
 
     implicit none
-  	
+
     ! Input parameters
     type(t_partit), intent(inout),   target          :: partit
     type(t_mesh)  , intent(inout),   target          :: mesh
@@ -113,10 +113,12 @@ subroutine Cobeta(partit, mesh)
     ! Constants
     real(kind=8), parameter                          :: nWater        = 1.33  ! Refractive indices of water
 
-#include "../associate_part_def.h"
-#include "../associate_mesh_def.h"
-#include "../associate_part_ass.h"
-#include "../associate_mesh_ass.h"
+    integer, pointer                       :: myDim_nod2D, eDim_nod2D
+    real(kind=WP), dimension(:,:), pointer :: geo_coord_nod2D
+
+    myDim_nod2D                                   => partit%myDim_nod2D
+    eDim_nod2D                                    => partit%eDim_nod2D
+    geo_coord_nod2D(1:2,1:myDim_nod2D+eDim_nod2D) => mesh%geo_coord_nod2D(:,:)
 
 !! find day (****NOTE for year starting in winter*****)  
 !! Paltridge, G. W. and C. M. R. Platt, Radiative Processes 

--- a/recom_extra.F90
+++ b/recom_extra.F90
@@ -1,20 +1,19 @@
 module recom_extra
     interface
-        subroutine Depth_calculations(n, nn, wf, zf, thick, recipthick, partit, mesh)
-            use mod_mesh, only: t_mesh
-            use MOD_PARTIT, only: t_partit
+        subroutine Depth_calculations(n, nn, wf, zf, thick, recipthick, myDim_nod2D, eDim_nod2D, nl, hnode, zbar_3d_n)
+            use o_param, only: wp
 
             ! Input parameters
-            type(t_partit), intent(inout),   target          :: partit
-            type(t_mesh)  , intent(inout),   target          :: mesh
-            integer       , intent(in)                       :: nn	    ! Total number of vertical nodes
-            integer       , intent(in)                       :: n           ! Current node
+            integer, intent(in)                        :: n           ! Current node
+            integer, intent(in)                        :: nn	    ! Total number of vertical nodes
+            integer, intent(in)                        :: myDim_nod2D, eDim_nod2D, nl
+            real(kind=WP), intent(in), dimension(:,:)  :: hnode, zbar_3d_n
 
             ! Output arrays
-            real(kind=8), dimension(mesh%nl,5), intent(out)  :: wf          ! [m/day] Flux velocities at the border of the control volumes
-            real(kind=8), dimension(mesh%nl),   intent(out)  :: zf          ! [m] Depth of vertical fluxes
-            real(kind=8), dimension(mesh%nl-1), intent(out)  :: thick       ! [m] Distance between two nodes = layer thickness
-            real(kind=8), dimension(mesh%nl-1), intent(out)  :: recipthick  ! [1/m] Reciprocal thickness
+            real(kind=8), dimension(nl,5), intent(out) :: wf          ! [m/day] Flux velocities at the border of the control volumes
+            real(kind=8), dimension(nl),   intent(out) :: zf          ! [m] Depth of vertical fluxes
+            real(kind=8), dimension(nl-1), intent(out) :: thick       ! [m] Distance between two nodes = layer thickness
+            real(kind=8), dimension(nl-1), intent(out) :: recipthick  ! [1/m] Reciprocal thickness
         end subroutine Depth_calculations
 
         subroutine Cobeta(daynew, ndpyr, myDim_nod2D, eDim_nod2D, geo_coord_nod2D)
@@ -35,37 +34,26 @@ end module recom_extra
 !===============================================================================
 ! Subroutine for calculating flux-depth and thickness of control volumes
 !===============================================================================
-subroutine Depth_calculations(n, nn, wf, zf, thick, recipthick, partit, mesh)
+subroutine Depth_calculations(n, nn, wf, zf, thick, recipthick, myDim_nod2D, eDim_nod2D, nl, hnode, zbar_3d_n)
     use recom_config
-    use mod_mesh, only: t_mesh
-    use MOD_PARTIT, only: t_partit
-    use g_clock, only: wp
+    use o_param, only: wp
 
     implicit none
 
     ! Input parameters
-    type(t_partit), intent(inout),   target          :: partit
-    type(t_mesh)  , intent(inout),   target          :: mesh
-    integer       , intent(in)                       :: nn	    ! Total number of vertical nodes
-    integer       , intent(in)                       :: n           ! Current node
+    integer, intent(in)                       :: n           ! Current node
+    integer, intent(in)                       :: nn	    ! Total number of vertical nodes
+    integer, intent(in)                       :: myDim_nod2D, eDim_nod2D, nl
+    real(kind=WP), intent(in), dimension(:,:) :: hnode, zbar_3d_n
 
     ! Output arrays
-    real(kind=8), dimension(mesh%nl,5), intent(out)  :: wf          ! [m/day] Flux velocities at the border of the control volumes
-    real(kind=8), dimension(mesh%nl),   intent(out)  :: zf          ! [m] Depth of vertical fluxes
-    real(kind=8), dimension(mesh%nl-1), intent(out)  :: thick       ! [m] Distance between two nodes = layer thickness
-    real(kind=8), dimension(mesh%nl-1), intent(out)  :: recipthick  ! [1/m] Reciprocal thickness
+    real(kind=8), dimension(nl,5), intent(out)  :: wf          ! [m/day] Flux velocities at the border of the control volumes
+    real(kind=8), dimension(nl),   intent(out)  :: zf          ! [m] Depth of vertical fluxes
+    real(kind=8), dimension(nl-1), intent(out)  :: thick       ! [m] Distance between two nodes = layer thickness
+    real(kind=8), dimension(nl-1), intent(out)  :: recipthick  ! [1/m] Reciprocal thickness
 
     ! Local variables
-    integer                                          :: k           ! Layer index
-
-    integer, pointer                       :: myDim_nod2D, eDim_nod2D
-    real(kind=WP), dimension(:,:), pointer :: hnode
-    real(kind=WP), dimension(:,:), pointer :: zbar_3d_n
-
-    myDim_nod2D                                    => partit%myDim_nod2D
-    eDim_nod2D                                     => partit%eDim_nod2D
-    hnode(1:mesh%nl-1, 1:myDim_nod2D+eDim_nod2D)   => mesh%hnode(:,:)
-    zbar_3d_n(1:mesh%nl, 1:myDim_nod2D+eDim_nod2D) => mesh%zbar_3d_n(:,:)
+    integer                                     :: k           ! Layer index
 
 ! ======================================================================================
 !! zbar(nl) allocate the array for storing the standard depths (depth of layers)

--- a/recom_extra.F90
+++ b/recom_extra.F90
@@ -28,6 +28,17 @@ module recom_extra
             integer, intent(in)                       :: myDim_nod2D, eDim_nod2D
             real(kind=WP), intent(in), dimension(:,:) :: geo_coord_nod2D
         end subroutine krill_resp
+
+        subroutine integrate_nod_2D_recom(data, int2D, partit, mesh)
+          USE MOD_PARTIT
+          USE MOD_MESH
+
+          IMPLICIT NONE
+          type(t_mesh),  intent(in),    target :: mesh
+          type(t_partit),intent(inout), target :: partit
+          real(kind=WP), intent(in)         :: data(:)
+          real(kind=WP), intent(inout)      :: int2D
+        end subroutine
     end interface
 end module recom_extra
 
@@ -202,3 +213,39 @@ subroutine krill_resp(n, daynew, myDim_nod2D, eDim_nod2D, geo_coord_nod2D)
       end if
    endif
  end subroutine krill_resp
+
+
+subroutine integrate_nod_2D_recom(data, int2D, partit, mesh)
+    USE MOD_PARTIT, only: t_partit, com_struct, mpi_sum, mpi_double_precision
+    USE MOD_MESH, only: t_mesh, wp, sparse_matrix
+
+    IMPLICIT NONE
+    type(t_mesh),  intent(in),    target :: mesh
+    type(t_partit),intent(inout), target :: partit
+    real(kind=WP), intent(in)         :: data(:)
+    real(kind=WP), intent(inout)      :: int2D
+
+    integer       :: row
+    real(kind=WP) :: lval
+
+    integer, pointer :: MPI_COMM_FESOM
+    integer, pointer :: MPIERR
+    integer, pointer :: myDim_nod2D, eDim_nod2D
+    integer,       dimension(:)  , pointer :: ulevels_nod2D
+    real(kind=WP), dimension(:,:), pointer :: areasvol
+
+    MPI_COMM_FESOM  => partit%MPI_COMM_FESOM
+    myDim_nod2D     => partit%myDim_nod2D
+    eDim_nod2D      => partit%eDim_nod2D
+    ulevels_nod2D(1:myDim_nod2D+eDim_nod2D) => mesh%ulevels_nod2D(:)
+    areasvol(1:mesh%nl,1:myDim_nod2d+eDim_nod2D) => mesh%areasvol(:,:)
+
+    lval=0.0_WP
+    do row=1, myDim_nod2D
+       lval=lval+data(row)*areasvol(ulevels_nod2D(row),row)
+    end do
+
+    int2D=0.0_WP
+    call MPI_AllREDUCE(lval, int2D, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
+                       MPI_COMM_FESOM, MPIerr)
+end subroutine integrate_nod_2D_recom

--- a/recom_extra.F90
+++ b/recom_extra.F90
@@ -3,16 +3,9 @@
 !===============================================================================
 subroutine Depth_calculations(n, nn, wf, zf, thick, recipthick, partit, mesh)
     use recom_config
-    use mod_mesh
-    use MOD_PARTIT
-    use MOD_PARSUP
-    use o_PARAM
-    use o_ARRAYS
-    use g_CONFIG
-    use g_forcing_arrays
-    use g_comm_auto
-    use g_clock
-    use g_rotate_grid
+    use mod_mesh, only: t_mesh, sparse_matrix
+    use MOD_PARTIT, only: t_partit, com_struct
+    use g_clock, only: wp
 
     implicit none
 

--- a/recom_extra.F90
+++ b/recom_extra.F90
@@ -1,3 +1,43 @@
+module recom_extra
+    interface
+        subroutine Depth_calculations(n, nn, wf, zf, thick, recipthick, partit, mesh)
+            use mod_mesh, only: t_mesh
+            use MOD_PARTIT, only: t_partit
+
+            ! Input parameters
+            type(t_partit), intent(inout),   target          :: partit
+            type(t_mesh)  , intent(inout),   target          :: mesh
+            integer       , intent(in)                       :: nn	    ! Total number of vertical nodes
+            integer       , intent(in)                       :: n           ! Current node
+
+            ! Output arrays
+            real(kind=8), dimension(mesh%nl,5), intent(out)  :: wf          ! [m/day] Flux velocities at the border of the control volumes
+            real(kind=8), dimension(mesh%nl),   intent(out)  :: zf          ! [m] Depth of vertical fluxes
+            real(kind=8), dimension(mesh%nl-1), intent(out)  :: thick       ! [m] Distance between two nodes = layer thickness
+            real(kind=8), dimension(mesh%nl-1), intent(out)  :: recipthick  ! [1/m] Reciprocal thickness
+        end subroutine Depth_calculations
+
+        subroutine Cobeta(partit, mesh)
+            use mod_mesh, only: t_mesh
+            use MOD_PARTIT, only: t_partit
+
+            ! Input parameters
+            type(t_partit), intent(inout),   target          :: partit
+            type(t_mesh)  , intent(inout),   target          :: mesh
+        end subroutine Cobeta
+
+        subroutine krill_resp(n, partit, mesh)
+            use mod_mesh, only: t_mesh
+            use MOD_PARTIT, only: t_partit
+
+            ! Input parameters
+            integer                                          :: n
+            type(t_partit), intent(inout),   target          :: partit
+            type(t_mesh)  , intent(inout),   target          :: mesh
+        end subroutine krill_resp
+    end interface
+end module recom_extra
+
 !===============================================================================
 ! Subroutine for calculating flux-depth and thickness of control volumes
 !===============================================================================

--- a/recom_forcing.F90
+++ b/recom_forcing.F90
@@ -251,7 +251,7 @@ if (recom_debug .and. mype==0) print *, achar(27)//'[36m'//'     --> REcoM_sms'/
         , kspc_watercolumn                                             & ! DISS stoichiometric solubility product [mol^2/kg^2]
         , rhoSW_watercolumn                                            & ! DISS in-situ density of seawater [kg/m3]
         , Loc_slp                                                      &
-        , zF, PAR, Lond, Latd, ice, dynamics, tracers, partit, mesh)
+        , zF, PAR, Lond, Latd, partit, mesh)
 
   state(1:nn,:)      = max(tiny,state(1:nn,:) + sms(1:nn,:))
 

--- a/recom_forcing.F90
+++ b/recom_forcing.F90
@@ -1,16 +1,62 @@
+module recom_forcing_module
+    interface
+        subroutine REcoM_Forcing(n, Nn, state, SurfSW, Loc_slp, Temp, Sali, Sali_depth,    &
+                                 CO2_watercolumn, pH_watercolumn, pCO2_watercolumn,        &
+                                 HCO3_watercolumn, CO3_watercolumn, OmegaC_watercolumn,    &
+                                 kspc_watercolumn, rhoSW_watercolumn, PAR, MPI_COMM_FESOM, &
+                                 mype, myDim_nod2D, eDim_nod2D, nl, hnode, zbar_3d_n,      &
+                                 geo_coord_nod2D, daynew, ndpyr, dt, kappa, mstep, rad)
+
+            use recom_declarations
+            use recom_locvar
+            use recom_config
+            use recom_glovar
+            use recom_extra
+            use recom_sms_module
+            use recom_ciso
+            use g_config, only: wp
+
+            implicit none
+
+            integer, intent(in) :: daynew, ndpyr, mype, myDim_nod2D, eDim_nod2D, nl, mstep
+            integer, intent(in) :: MPI_COMM_FESOM, n, Nn         ! Nn -Total number of nodes
+
+            real(kind=8), intent(in)    :: rad
+            real(kind=8), intent(in)    :: Sali              ! Salinity of current surface layer
+            real(kind=8), intent(in)    :: SurfSW        ! [W/m2] ShortWave radiation at surface
+            real(kind=8), intent(in)    :: Loc_slp       ! [Pa] sea-level pressure
+            real(kind=8), intent(inout) :: kappa, dt
+
+            real(kind=8), intent(in), dimension(nl - 1) :: Temp          ! [degrees C] Ocean temperature
+            real(kind=8), intent(in), dimension(nl - 1) :: Sali_depth    ! Salinity for the whole water column
+
+            !!---- Watercolumn carbonate chemistry
+            real(kind=8), intent(inout), dimension(nl - 1) :: CO2_watercolumn
+            real(kind=8), intent(inout), dimension(nl - 1) :: pH_watercolumn
+            real(kind=8), intent(inout), dimension(nl - 1) :: pCO2_watercolumn
+            real(kind=8), intent(inout), dimension(nl - 1) :: HCO3_watercolumn
+            real(kind=8), intent(inout), dimension(nl - 1) :: CO3_watercolumn
+            real(kind=8), intent(inout), dimension(nl - 1) :: OmegaC_watercolumn
+            real(kind=8), intent(inout), dimension(nl - 1) :: kspc_watercolumn
+            real(kind=8), intent(inout), dimension(nl - 1) :: rhoSW_watercolumn
+            real(kind=8), intent(inout), dimension(nl - 1) :: PAR
+
+            real(kind=WP), intent(in),    dimension(:, :) :: hnode, zbar_3d_n
+            real(kind=WP), intent(in),    dimension(:, :) :: geo_coord_nod2D
+            real(kind=8),  intent(inout), dimension(nl - 1, bgc_num) :: state
+        end subroutine recom_forcing
+    end interface
+end module recom_forcing_module
+
 !===============================================================================
 ! REcoM_Forcing
 !===============================================================================
-subroutine REcoM_Forcing(zNodes, n, Nn, state, SurfSW, Loc_slp, Temp, Sali, Sali_depth &
-            , CO2_watercolumn                                          &
-            , pH_watercolumn                                           &
-            , pCO2_watercolumn                                         &
-            , HCO3_watercolumn                                         &
-            , CO3_watercolumn                                          &
-            , OmegaC_watercolumn                                       &
-            , kspc_watercolumn                                         &
-            , rhoSW_watercolumn                                        &
-            , PAR, partit, mesh)
+subroutine REcoM_Forcing(n, Nn, state, SurfSW, Loc_slp, Temp, Sali, Sali_depth,    &
+                         CO2_watercolumn, pH_watercolumn, pCO2_watercolumn,        &
+                         HCO3_watercolumn, CO3_watercolumn, OmegaC_watercolumn,    &
+                         kspc_watercolumn, rhoSW_watercolumn, PAR, MPI_COMM_FESOM, &
+                         mype, myDim_nod2D, eDim_nod2D, nl, hnode, zbar_3d_n,      &
+                         geo_coord_nod2D, daynew, ndpyr, dt, kappa, mstep, rad)
 
     use recom_declarations
     use recom_locvar
@@ -19,81 +65,71 @@ subroutine REcoM_Forcing(zNodes, n, Nn, state, SurfSW, Loc_slp, Temp, Sali, Sali
     use recom_extra
     use recom_sms_module
     use recom_ciso
-
     use gasx
-    use g_clock, only: daynew, ndpyr
-    use g_config, only: dt, wp, kappa, mstep, rad
-    use mod_mesh, only: t_mesh, sparse_matrix
-    USE MOD_PARTIT, only: t_partit, com_struct
+    use g_config, only: wp
 
     implicit none
 
-    type(t_partit), intent(inout), target :: partit
-    type(t_mesh)  , intent(inout), target :: mesh
+    integer, intent(in) :: daynew, ndpyr, mype, myDim_nod2D, eDim_nod2D, nl, mstep
+    integer, intent(in) :: MPI_COMM_FESOM, n, Nn         ! Nn -Total number of nodes
 
-    real(kind=8)                              :: Latr          
-    integer                                   :: n, Nn         ! Nn -Total number of nodes
-    real(kind=8),dimension(mesh%nl-1)	      :: zNodes	       ! Depth of nodes   zr(1:nzmax) = Z_3d_n(1:nzmax,n)
-    real(kind=8),dimension(mesh%nl-1,bgc_num) :: state         	
-    real(kind=8)                              :: SurfSW        ! [W/m2] ShortWave radiation at surface
-    real(kind=8)                              :: Loc_slp       ! [Pa] sea-level pressure
-    real(kind=8),dimension(mesh%nl-1)         :: Temp          ! [degrees C] Ocean temperature
-    real(kind=8),dimension(mesh%nl-1)         :: Sali_depth    ! Salinity for the whole water column
+    real(kind=8), intent(in)    :: rad
+    real(kind=8), intent(in)    :: Sali              ! Salinity of current surface layer
+    real(kind=8), intent(in)    :: SurfSW        ! [W/m2] ShortWave radiation at surface
+    real(kind=8), intent(in)    :: Loc_slp       ! [Pa] sea-level pressure
+    real(kind=8), intent(inout) :: kappa, dt
+
+    real(kind=8), intent(in), dimension(nl - 1) :: Temp          ! [degrees C] Ocean temperature
+    real(kind=8), intent(in), dimension(nl - 1) :: Sali_depth    ! Salinity for the whole water column
 
     !!---- Watercolumn carbonate chemistry
-    real(kind=8),dimension(mesh%nl-1)         :: CO2_watercolumn
-    real(kind=8),dimension(mesh%nl-1)         :: pH_watercolumn
-    real(kind=8),dimension(mesh%nl-1)         :: pCO2_watercolumn
-    real(kind=8),dimension(mesh%nl-1)         :: HCO3_watercolumn
-    real(kind=8),dimension(mesh%nl-1)         :: CO3_watercolumn
-    real(kind=8),dimension(mesh%nl-1)         :: OmegaC_watercolumn
-    real(kind=8),dimension(mesh%nl-1)         :: kspc_watercolumn
-    real(kind=8),dimension(mesh%nl-1)         :: rhoSW_watercolumn
+    real(kind=8), intent(inout), dimension(nl - 1) :: CO2_watercolumn
+    real(kind=8), intent(inout), dimension(nl - 1) :: pH_watercolumn
+    real(kind=8), intent(inout), dimension(nl - 1) :: pCO2_watercolumn
+    real(kind=8), intent(inout), dimension(nl - 1) :: HCO3_watercolumn
+    real(kind=8), intent(inout), dimension(nl - 1) :: CO3_watercolumn
+    real(kind=8), intent(inout), dimension(nl - 1) :: OmegaC_watercolumn
+    real(kind=8), intent(inout), dimension(nl - 1) :: kspc_watercolumn
+    real(kind=8), intent(inout), dimension(nl - 1) :: rhoSW_watercolumn
+    real(kind=8), intent(inout), dimension(nl - 1) :: PAR
 
-    real(kind=8),dimension(mesh%nl-1)         :: PAR
+    real(kind=WP), intent(in),    dimension(:, :) :: hnode, zbar_3d_n
+    real(kind=WP), intent(in),    dimension(:, :) :: geo_coord_nod2D
+    real(kind=8),  intent(inout), dimension(nl - 1, bgc_num) :: state
+
+    integer :: tr_num
+    real(kind=8) :: Latr
+
+    !!---- Subroutine CO2Flux /mocsy
+    real(kind=8) :: REcoM_DIC(1)         ! [mol/m3] Conc of DIC in the surface water, used to calculate CO2 flux
+    real(kind=8) :: REcoM_Alk(1)         ! [mol/m3] Conc of Alk in the surface water, used to calculate CO2 flux
+    real(kind=8) :: REcoM_Si(1)          ! [mol/m3] Conc of Si in the surface water, used to calculate CO2 flux
+    real(kind=8) :: REcoM_Phos(1)        ! [mol/m3] Conc of Phos in the surface water, used to calculate the CO2 flux
+    real(kind=8) :: Latd(1)              ! latitude in degree
+    real(kind=8) :: Lond(1)              ! longitude in degree
+    real(kind=8) :: REcoM_T(1)           ! temperature again, for mocsy minimum defined as -2
+    real(kind=8) :: REcoM_S(1)           ! temperature again, for mocsy minimum defined as 21
+
+! atm pressure, now read in as forcing!!
+    !!---- atm pressure
+    real(kind=8) :: Patm(1)              ! atmospheric pressure [atm]
+
+    !!---- Subroutine o2flux /mocsy 
+    real(kind=8) :: ppo(1)               ! atmospheric pressure, divided by 1 atm 
+    real(kind=8) :: REcoM_O2(1)          ! [mmol/m3] Conc of O2 in the surface water, used to calculate O2 flux
+
+    !!---- Diagnostics
+    integer :: idiags,k
 
     !!---- Subroutine Depth
 
-    real(kind=8),dimension(mesh%nl)           :: zF                   ! [m] Depth of fluxes
-    real(kind=8),dimension(mesh%nl,6)         :: SinkVel              ! [m/day]
-    real(kind=8),dimension(mesh%nl-1)         :: thick                ! [m] Vertical distance between two nodes = Thickness 
-    real(kind=8),dimension(mesh%nl-1)         :: recipthick           ! [1/m] reciprocal of thick
-
-    !!---- Subroutine CO2Flux /mocsy
-    real(kind=8)                              :: REcoM_DIC(1)         ! [mol/m3] Conc of DIC in the surface water, used to calculate CO2 flux
-    real(kind=8)                              :: REcoM_Alk(1)         ! [mol/m3] Conc of Alk in the surface water, used to calculate CO2 flux
-    real(kind=8)                              :: REcoM_Si(1)          ! [mol/m3] Conc of Si in the surface water, used to calculate CO2 flux
-    real(kind=8)                              :: REcoM_Phos(1)        ! [mol/m3] Conc of Phos in the surface water, used to calculate the CO2 flux
-    real(kind=8)                              :: Sali(1)              ! Salinity of current surface layer
-    real(kind=8)                              :: Latd(1)              ! latitude in degree
-    real(kind=8)                              :: Lond(1)              ! longitude in degree
-    real(kind=8)                              :: REcoM_T(1)           ! temperature again, for mocsy minimum defined as -2
-    real(kind=8)                              :: REcoM_S(1)           ! temperature again, for mocsy minimum defined as 21
-! atm pressure, now read in as forcing!!
-    !!---- atm pressure
-    real(kind=8)                              :: Patm(1)              ! atmospheric pressure [atm]
-
-    !!---- Subroutine o2flux /mocsy 
-    real(kind=8)                              :: ppo(1)               ! atmospheric pressure, divided by 1 atm 
-    real(kind=8)                              :: REcoM_O2(1)          ! [mmol/m3] Conc of O2 in the surface water, used to calculate O2 flux
+    real(kind=8),dimension(nl)           :: zF                   ! [m] Depth of fluxes
+    real(kind=8),dimension(nl,6)         :: SinkVel              ! [m/day]
+    real(kind=8),dimension(nl-1)         :: thick                ! [m] Vertical distance between two nodes = Thickness 
+    real(kind=8),dimension(nl-1)         :: recipthick           ! [1/m] reciprocal of thick
 
     !!---- Subroutine REcoM_sms
-    real(kind=8),dimension(mesh%nl-1,bgc_num) :: sms                  ! matrix that entail changes in tracer concentrations
-
-    !!---- Diagnostics
-    integer                                   :: idiags,k
-
-    integer                    :: tr_num
-
-    integer, pointer   :: mype
-    integer, pointer                :: myDim_nod2D, eDim_nod2D
-    real(kind=WP), dimension(:,:), pointer :: geo_coord_nod2D
-
-    mype            => partit%mype
-    myDim_nod2D     => partit%myDim_nod2D
-    eDim_nod2D      => partit%eDim_nod2D
-
-    geo_coord_nod2D(1:2,1:myDim_nod2D+eDim_nod2D)              => mesh%geo_coord_nod2D(:,:)
+    real(kind=8), dimension(nl-1, bgc_num) :: sms                  ! matrix that entail changes in tracer concentrations
 
     tiny_N   = tiny_chl/chl2N_max   ! 0.00001/ 3.15d0   Chl2N_max [mg CHL/mmol N] Maximum CHL a : N ratio = 0.3 gCHL gN^-1
     tiny_N_d = tiny_chl/chl2N_max_d ! 0.00001/ 4.2d0
@@ -111,8 +147,8 @@ if (enable_coccos) then
     tiny_C_p = tiny_N_p/NCmax_p     ! NCmax_c = 0.15d0
 endif
 
-    call Cobeta(daynew, ndpyr, partit%myDim_nod2D, partit%eDim_nod2D, mesh%geo_coord_nod2D)
-    call Depth_calculations(n, Nn,SinkVel,zF,thick,recipthick, partit%myDim_nod2D, partit%eDim_nod2D, mesh%nl, mesh%hnode, mesh%zbar_3d_n)
+    call Cobeta(daynew, ndpyr, myDim_nod2D, eDim_nod2D, geo_coord_nod2D)
+    call Depth_calculations(n, Nn,SinkVel,zF,thick,recipthick, myDim_nod2D, eDim_nod2D, nl, hnode, zbar_3d_n)
 
     !! *** Mocsy ***
 
@@ -130,7 +166,7 @@ endif
     REcoM_T    = min(REcoM_T, 40.d0) 
 
     !!---- minimum set to 21: K1/K2 Lueker valid between 2degC-35degC and 19-43psu, else causes trouble in regions with S between 19 and 21 and ice conc above 97%
-    REcoM_S    = max(21.d0, Sali(1)) 
+    REcoM_S    = max(21.d0, Sali)
     !!---- maximum set to 43: K1/K2 Lueker valid between 2degC-35degC and 19-43psu, else causes trouble   REcoM_S    = min(REcoM_S, 43.d0)  !!!!!!!!
 
     !!---- convert from Pa to atm.
@@ -231,20 +267,18 @@ endif
 
 if (recom_debug .and. mype==0) print *, achar(27)//'[36m'//'     --> REcoM_sms'//achar(27)//'[0m'
 
-!  call REcoM_sms(n, Nn, state, thick, recipthick, SurfSW, sms, Temp ,zF, PAR, mesh)
-
   call REcoM_sms(n, Nn, state, thick, SurfSW, sms, Temp, Sali_depth, &
-                 CO2_watercolumn,                                                & ! MOCSY [mol/m3]
-                 pH_watercolumn,                                                 & ! MOCSY on total scale
-                 pCO2_watercolumn,                                               & ! MOCSY [uatm]
-                 HCO3_watercolumn,                                               & ! MOCSY [mol/m3]
-                 CO3_watercolumn,                                                & ! DISS [mol/m3]
-                 OmegaC_watercolumn,                                             & ! DISS calcite saturation state
-                 kspc_watercolumn,                                               & ! DISS stoichiometric solubility product [mol^2/kg^2]
-                 rhoSW_watercolumn,                                              & ! DISS in-situ density of seawater [kg/m3]
-                 Loc_slp,                                                        &
-                 zF, PAR, Latd, daynew, dt, kappa, mstep, partit%MPI_COMM_FESOM, &
-                 partit%mype, partit%myDim_nod2D, partit%eDim_nod2D, mesh%nl, mesh%geo_coord_nod2D)
+                 CO2_watercolumn,                                               & ! MOCSY [mol/m3]
+                 pH_watercolumn,                                                & ! MOCSY on total scale
+                 pCO2_watercolumn,                                              & ! MOCSY [uatm]
+                 HCO3_watercolumn,                                              & ! MOCSY [mol/m3]
+                 CO3_watercolumn,                                               & ! DISS [mol/m3]
+                 OmegaC_watercolumn,                                            & ! DISS calcite saturation state
+                 kspc_watercolumn,                                              & ! DISS stoichiometric solubility product [mol^2/kg^2]
+                 rhoSW_watercolumn,                                             & ! DISS in-situ density of seawater [kg/m3]
+                 Loc_slp,                                                       &
+                 zF, PAR, Latd, daynew, dt, kappa, mstep, MPI_COMM_FESOM, mype, &
+                 myDim_nod2D, eDim_nod2D, nl, geo_coord_nod2D)
 
   state(1:nn,:)      = max(tiny,state(1:nn,:) + sms(1:nn,:))
 

--- a/recom_forcing.F90
+++ b/recom_forcing.F90
@@ -16,6 +16,7 @@ subroutine REcoM_Forcing(zNodes, n, Nn, state, SurfSW, Loc_slp, Temp, Sali, Sali
     use recom_locvar
     use recom_config
     use recom_glovar
+    use recom_extra
     use gasx
     use recom_ciso
     use g_clock
@@ -118,7 +119,7 @@ if (enable_coccos) then
     tiny_C_p = tiny_N_p/NCmax_p     ! NCmax_c = 0.15d0
 endif
 
-    call Cobeta(partit, mesh)      
+    call Cobeta(daynew, ndpyr, partit%myDim_nod2D, partit%eDim_nod2D, mesh%geo_coord_nod2D)
     call Depth_calculations(n, Nn,SinkVel,zF,thick,recipthick, partit, mesh)
 
     !! *** Mocsy ***

--- a/recom_forcing.F90
+++ b/recom_forcing.F90
@@ -10,7 +10,7 @@ subroutine REcoM_Forcing(zNodes, n, Nn, state, SurfSW, Loc_slp, Temp, Sali, Sali
             , OmegaC_watercolumn                                       &
             , kspc_watercolumn                                         &
             , rhoSW_watercolumn                                        &
-            , PAR, ice, dynamics, tracers, partit, mesh)
+            , PAR, partit, mesh)
 
     use recom_declarations
     use recom_locvar
@@ -25,15 +25,9 @@ subroutine REcoM_Forcing(zNodes, n, Nn, state, SurfSW, Loc_slp, Temp, Sali, Sali
     use g_config, only: dt, wp, kappa, mstep, rad
     use mod_mesh, only: t_mesh, sparse_matrix
     USE MOD_PARTIT, only: t_partit, com_struct
-    use mod_tracer, only: t_tracer
-    use MOD_DYN, only: t_dyn
-    use MOD_ICE, only: t_ice
 
     implicit none
 
-    type(t_dyn)   , intent(inout), target :: dynamics
-    type(t_ice)   , intent(inout), target :: ice
-    type(t_tracer), intent(inout), target :: tracers
     type(t_partit), intent(inout), target :: partit
     type(t_mesh)  , intent(inout), target :: mesh
 

--- a/recom_forcing.F90
+++ b/recom_forcing.F90
@@ -241,7 +241,7 @@ if (recom_debug .and. mype==0) print *, achar(27)//'[36m'//'     --> REcoM_sms'/
 
 !  call REcoM_sms(n, Nn, state, thick, recipthick, SurfSW, sms, Temp ,zF, PAR, mesh)
 
-  call REcoM_sms(n, Nn, state, thick, recipthick, SurfSW, sms, Temp, Sali_depth &
+  call REcoM_sms(n, Nn, state, thick, SurfSW, sms, Temp, Sali_depth &
         , CO2_watercolumn                                              & ! MOCSY [mol/m3]
         , pH_watercolumn                                               & ! MOCSY on total scale
         , pCO2_watercolumn                                             & ! MOCSY [uatm]
@@ -251,7 +251,7 @@ if (recom_debug .and. mype==0) print *, achar(27)//'[36m'//'     --> REcoM_sms'/
         , kspc_watercolumn                                             & ! DISS stoichiometric solubility product [mol^2/kg^2]
         , rhoSW_watercolumn                                            & ! DISS in-situ density of seawater [kg/m3]
         , Loc_slp                                                      &
-        , zF, PAR, Lond, Latd, partit, mesh)
+        , zF, PAR, Latd, partit, mesh)
 
   state(1:nn,:)      = max(tiny,state(1:nn,:) + sms(1:nn,:))
 

--- a/recom_forcing.F90
+++ b/recom_forcing.F90
@@ -17,6 +17,7 @@ subroutine REcoM_Forcing(zNodes, n, Nn, state, SurfSW, Loc_slp, Temp, Sali, Sali
     use recom_config
     use recom_glovar
     use recom_extra
+    use recom_sms_module
     use gasx
     use recom_ciso
     use g_clock
@@ -241,17 +242,18 @@ if (recom_debug .and. mype==0) print *, achar(27)//'[36m'//'     --> REcoM_sms'/
 
 !  call REcoM_sms(n, Nn, state, thick, recipthick, SurfSW, sms, Temp ,zF, PAR, mesh)
 
-  call REcoM_sms(n, Nn, state, thick, SurfSW, sms, Temp, Sali_depth &
-        , CO2_watercolumn                                              & ! MOCSY [mol/m3]
-        , pH_watercolumn                                               & ! MOCSY on total scale
-        , pCO2_watercolumn                                             & ! MOCSY [uatm]
-        , HCO3_watercolumn                                             & ! MOCSY [mol/m3]
-        , CO3_watercolumn                                              & ! DISS [mol/m3]
-        , OmegaC_watercolumn                                           & ! DISS calcite saturation state
-        , kspc_watercolumn                                             & ! DISS stoichiometric solubility product [mol^2/kg^2]
-        , rhoSW_watercolumn                                            & ! DISS in-situ density of seawater [kg/m3]
-        , Loc_slp                                                      &
-        , zF, PAR, Latd, partit, mesh)
+  call REcoM_sms(n, Nn, state, thick, SurfSW, sms, Temp, Sali_depth, &
+                 CO2_watercolumn,                                                & ! MOCSY [mol/m3]
+                 pH_watercolumn,                                                 & ! MOCSY on total scale
+                 pCO2_watercolumn,                                               & ! MOCSY [uatm]
+                 HCO3_watercolumn,                                               & ! MOCSY [mol/m3]
+                 CO3_watercolumn,                                                & ! DISS [mol/m3]
+                 OmegaC_watercolumn,                                             & ! DISS calcite saturation state
+                 kspc_watercolumn,                                               & ! DISS stoichiometric solubility product [mol^2/kg^2]
+                 rhoSW_watercolumn,                                              & ! DISS in-situ density of seawater [kg/m3]
+                 Loc_slp,                                                        &
+                 zF, PAR, Latd, daynew, dt, kappa, mstep, partit%MPI_COMM_FESOM, &
+                 partit%mype, partit%myDim_nod2D, partit%eDim_nod2D, mesh%nl, mesh%geo_coord_nod2D)
 
   state(1:nn,:)      = max(tiny,state(1:nn,:) + sms(1:nn,:))
 

--- a/recom_forcing.F90
+++ b/recom_forcing.F90
@@ -18,24 +18,17 @@ subroutine REcoM_Forcing(zNodes, n, Nn, state, SurfSW, Loc_slp, Temp, Sali, Sali
     use recom_glovar
     use recom_extra
     use recom_sms_module
-    use gasx
     use recom_ciso
-    use g_clock
-    use o_PARAM
-    use g_rotate_grid
-    use g_config
-    use mod_mesh
-    USE MOD_PARTIT
-    USE MOD_PARSUP
-    use mod_tracer
-    use MOD_DYN
-    use MOD_ICE
 
-    use o_param
-    use o_arrays
-    use g_forcing_arrays
-    use g_comm_auto
-    use g_support
+    use gasx
+    use g_clock, only: daynew, ndpyr
+    use g_config, only: dt, wp, kappa, mstep, rad
+    use mod_mesh, only: t_mesh, sparse_matrix
+    USE MOD_PARTIT, only: t_partit, com_struct
+    use mod_tracer, only: t_tracer
+    use MOD_DYN, only: t_dyn
+    use MOD_ICE, only: t_ice
+
     implicit none
 
     type(t_dyn)   , intent(inout), target :: dynamics

--- a/recom_forcing.F90
+++ b/recom_forcing.F90
@@ -85,11 +85,15 @@ subroutine REcoM_Forcing(zNodes, n, Nn, state, SurfSW, Loc_slp, Temp, Sali, Sali
 
     integer                    :: tr_num
 
-#include "../associate_part_def.h"
-#include "../associate_mesh_def.h"
-#include "../associate_part_ass.h"
-#include "../associate_mesh_ass.h"
+    integer, pointer   :: mype
+    integer, pointer                :: myDim_nod2D, eDim_nod2D
+    real(kind=WP), dimension(:,:), pointer :: geo_coord_nod2D
 
+    mype            => partit%mype
+    myDim_nod2D     => partit%myDim_nod2D
+    eDim_nod2D      => partit%eDim_nod2D
+
+    geo_coord_nod2D(1:2,1:myDim_nod2D+eDim_nod2D)              => mesh%geo_coord_nod2D(:,:)
 
     tiny_N   = tiny_chl/chl2N_max   ! 0.00001/ 3.15d0   Chl2N_max [mg CHL/mmol N] Maximum CHL a : N ratio = 0.3 gCHL gN^-1
     tiny_N_d = tiny_chl/chl2N_max_d ! 0.00001/ 4.2d0

--- a/recom_forcing.F90
+++ b/recom_forcing.F90
@@ -120,7 +120,7 @@ if (enable_coccos) then
 endif
 
     call Cobeta(daynew, ndpyr, partit%myDim_nod2D, partit%eDim_nod2D, mesh%geo_coord_nod2D)
-    call Depth_calculations(n, Nn,SinkVel,zF,thick,recipthick, partit, mesh)
+    call Depth_calculations(n, Nn,SinkVel,zF,thick,recipthick, partit%myDim_nod2D, partit%eDim_nod2D, mesh%nl, mesh%hnode, mesh%zbar_3d_n)
 
     !! *** Mocsy ***
 

--- a/recom_main.F90
+++ b/recom_main.F90
@@ -389,7 +389,7 @@ endif
            , OmegaC_watercolumn                                  & ! NEW DISS OmegaC for the whole watercolumn
            , kspc_watercolumn                                    & ! NEW DISS stoichiometric solubility product for calcite [mol^2/kg^2]
            , rhoSW_watercolumn                                   & ! NEW DISS in-situ density of seawater [mol/m^3]
-                           , PAR, ice, dynamics, tracers, partit, mesh)
+           , PAR, partit, mesh)
 
         do tr_num = num_tracers-bgc_num+1, num_tracers !bgc_num+2
             tracers%data(tr_num)%values(1:nzmax, n) = C(1:nzmax, tr_num-2)

--- a/recom_main.F90
+++ b/recom_main.F90
@@ -67,6 +67,7 @@ subroutine recom(ice, dynamics, tracers, partit, mesh)
     use g_clock
     use g_forcing_arrays, only: press_air, u_wind, v_wind, shortwave
     use g_comm_auto
+    use recom_forcing_module
 
     implicit none
 
@@ -380,16 +381,18 @@ endif
 
 ! ======================================================================================
 !******************************** RECOM FORCING ****************************************
-        call REcoM_Forcing(zr, n, nzmax, C, SW, Loc_slp, Temp, Sali, Sali_depth &
-           , CO2_watercolumn                                     & ! NEW MOCSY CO2 for the whole watercolumn
-           , pH_watercolumn                                      & ! NEW MOCSY pH for the whole watercolumn
-           , pCO2_watercolumn                                    & ! NEW MOCSY pCO2 for the whole watercolumn
-           , HCO3_watercolumn                                    & ! NEW MOCSY HCO3 for the whole watercolumn
-           , CO3_watercolumn                                     & ! NEW DISS CO3 for the whole watercolumn
-           , OmegaC_watercolumn                                  & ! NEW DISS OmegaC for the whole watercolumn
-           , kspc_watercolumn                                    & ! NEW DISS stoichiometric solubility product for calcite [mol^2/kg^2]
-           , rhoSW_watercolumn                                   & ! NEW DISS in-situ density of seawater [mol/m^3]
-           , PAR, partit, mesh)
+        call REcoM_Forcing(n, nzmax, C, SW, Loc_slp, Temp, Sali, Sali_depth, &
+                           CO2_watercolumn,         & ! NEW MOCSY CO2 for the whole watercolumn
+                           pH_watercolumn,          & ! NEW MOCSY pH for the whole watercolumn
+                           pCO2_watercolumn,        & ! NEW MOCSY pCO2 for the whole watercolumn
+                           HCO3_watercolumn,        & ! NEW MOCSY HCO3 for the whole watercolumn
+                           CO3_watercolumn,         & ! NEW DISS CO3 for the whole watercolumn
+                           OmegaC_watercolumn,      & ! NEW DISS OmegaC for the whole watercolumn
+                           kspc_watercolumn,        & ! NEW DISS stoichiometric solubility product for calcite [mol^2/kg^2]
+                           rhoSW_watercolumn,       & ! NEW DISS in-situ density of seawater [mol/m^3]
+                           PAR, partit%MPI_COMM_FESOM, partit%mype, partit%myDim_nod2D, &
+                           partit%eDim_nod2D, mesh%nl, mesh%hnode, mesh%zbar_3d_n,    &
+                           mesh%geo_coord_nod2D, daynew, ndpyr, dt, kappa, mstep, rad)
 
         do tr_num = num_tracers-bgc_num+1, num_tracers !bgc_num+2
             tracers%data(tr_num)%values(1:nzmax, n) = C(1:nzmax, tr_num-2)

--- a/recom_main.F90
+++ b/recom_main.F90
@@ -662,11 +662,6 @@ subroutine bio_fluxes(tracers, partit, mesh)
     !___________________________________________________________________________
     real(kind=WP), dimension(:,:), pointer :: alkalinity
 
-#include "../associate_part_def.h"
-#include "../associate_mesh_def.h"
-#include "../associate_part_ass.h"
-#include "../associate_mesh_ass.h"
-
     alkalinity => tracers%data(2+ialk)%values(:,:) ! 1 temp, 2 salt, 3 din, 4 dic, 5 alk
 !___________________________________________________________________
 ! on freshwater inflow/outflow or virtual alkalinity:
@@ -694,7 +689,7 @@ subroutine bio_fluxes(tracers, partit, mesh)
 
     !___________________________________________________________________________
     ! Balance alkalinity restoring to climatology
-    do n=1, myDim_nod2D+eDim_nod2D
+    do n=1, partit%myDim_nod2D + partit%eDim_nod2D
 !        relax_alk(n)=surf_relax_Alk * (Alk_surf(n) - tracers%data(2+ialk)%values(1, n)) 
 !        relax_alk(n)=surf_relax_Alk * (Alk_surf(n) - alkalinity(ulevels_nod2d(n),n)
         relax_alk(n)=surf_relax_Alk * (Alk_surf(n) - alkalinity(1, n))
@@ -710,6 +705,6 @@ subroutine bio_fluxes(tracers, partit, mesh)
   ! 3. restoring to Alkalinity climatology
     call integrate_nod_2D_recom(relax_alk, net, partit%MPI_COMM_FESOM, partit%myDim_nod2D, partit%eDim_nod2D, mesh%ulevels_nod2D, mesh%areasvol)
 
-    relax_alk=relax_alk-net/ocean_area  ! at ocean surface layer
+    relax_alk = relax_alk - net / mesh%ocean_area  ! at ocean surface layer
 
 end subroutine bio_fluxes

--- a/recom_main.F90
+++ b/recom_main.F90
@@ -23,21 +23,9 @@ end module
 module bio_fluxes_interface
     interface
         subroutine bio_fluxes(tracers, partit, mesh)
-            use recom_declarations
-            use recom_locvar
-            use recom_glovar
-            use recom_config
-
-            use mod_mesh
-            use MOD_PARTIT
-            use MOD_PARSUP
-            use mod_tracer
-
-            use g_config
-            use o_arrays
-            use g_comm_auto
-            use g_forcing_arrays
-            use g_support
+            use mod_mesh, only: t_mesh
+            use MOD_PARTIT, only: t_partit
+            use mod_tracer, only: t_tracer
 
             type(t_tracer), intent(inout), target :: tracers
             type(t_partit), intent(inout), target :: partit
@@ -638,18 +626,12 @@ subroutine bio_fluxes(tracers, partit, mesh)
     use recom_locvar
     use recom_glovar
     use recom_config
-
-    use mod_mesh
-    use MOD_PARTIT
-    use MOD_PARSUP
-    use mod_tracer
-
-    use g_config
-    use o_arrays
-    use g_comm_auto
-    use g_forcing_arrays
-    use g_support
     use recom_extra, only: integrate_nod_2d_recom
+
+    use mod_mesh, only: t_mesh
+    use MOD_PARTIT, only: t_partit
+    use mod_tracer, only: t_tracer
+    use g_config, only: wp
 
     implicit none
     integer                               :: n, elem, elnodes(3),n1

--- a/recom_main.F90
+++ b/recom_main.F90
@@ -708,7 +708,7 @@ subroutine bio_fluxes(tracers, partit, mesh)
 
 
   ! 3. restoring to Alkalinity climatology
-    call integrate_nod_2D_recom(relax_alk, net, partit, mesh)
+    call integrate_nod_2D_recom(relax_alk, net, partit%MPI_COMM_FESOM, partit%myDim_nod2D, partit%eDim_nod2D, mesh%ulevels_nod2D, mesh%areasvol)
 
     relax_alk=relax_alk-net/ocean_area  ! at ocean surface layer
 

--- a/recom_main.F90
+++ b/recom_main.F90
@@ -649,6 +649,7 @@ subroutine bio_fluxes(tracers, partit, mesh)
     use g_comm_auto
     use g_forcing_arrays
     use g_support
+    use recom_extra, only: integrate_nod_2d_recom
 
     implicit none
     integer                               :: n, elem, elnodes(3),n1
@@ -707,7 +708,7 @@ subroutine bio_fluxes(tracers, partit, mesh)
 
 
   ! 3. restoring to Alkalinity climatology
-    call integrate_nod(relax_alk, net, partit, mesh)
+    call integrate_nod_2D_recom(relax_alk, net, partit, mesh)
 
     relax_alk=relax_alk-net/ocean_area  ! at ocean surface layer
 

--- a/recom_main.F90
+++ b/recom_main.F90
@@ -131,7 +131,9 @@ subroutine recom(ice, dynamics, tracers, partit, mesh)
 
   if (use_atbox) then    ! MERGE
 ! Prognostic atmospheric isoCO2
-    call recom_atbox(partit,mesh)
+    call recom_atbox(partit, mesh, partit%MPI_COMM_FESOM, partit%myDim_nod2D, &
+                     partit%eDim_nod2D, mesh%ocean_area, mesh%ulevels_nod2D,  &
+                     mesh%areasvol)
 !   optional I/O of isoCO2 and inferred cosmogenic 14C production; this may cost some CPU time
     if (ciso .and. ciso_14) then
       call annual_event(do_update)

--- a/recom_sms.F90
+++ b/recom_sms.F90
@@ -14,6 +14,7 @@ subroutine REcoM_sms(n,Nn,state,thick,recipthick,SurfSR,sms,Temp, Sali_depth &
     use recom_glovar
     use recom_config
     use recoM_ciso
+    use recom_extra
     use g_clock
 
     use g_config
@@ -3365,7 +3366,7 @@ real(kind=8) :: &
 
            ! Call detailed krill respiration subroutine
            ! Handles additional physiological processes (e.g., molting, reproduction)
-           call krill_resp(n, partit, mesh)
+           call krill_resp(n, daynew, partit%myDim_nod2D, partit%eDim_nod2D, mesh%geo_coord_nod2D)
 
            ! Calculate feeding success modifier
            ! Low feeding rates trigger stress response with elevated respiration

--- a/recom_sms.F90
+++ b/recom_sms.F90
@@ -18,8 +18,8 @@ subroutine REcoM_sms(n,Nn,state,thick,SurfSR,sms,Temp, Sali_depth &
 
     use g_clock, only: daynew
     use g_config, only: dt, wp, kappa, mstep
-    use MOD_MESH, only: t_mesh, sparse_matrix
-    USE MOD_PARTIT, only: t_partit, com_struct
+    use MOD_MESH, only: t_mesh
+    USE MOD_PARTIT, only: t_partit
     use mvars, only: vars_sprac
 
     implicit none
@@ -117,11 +117,8 @@ real(kind=8) :: &
     MicZooN,   & ! [mmol/m3] Microzooplankton nitrogen
     MicZooC      ! [mmol/m3] Microzooplankton carbon
 
-#include "../associate_part_def.h"
-#include "../associate_mesh_def.h"
-#include "../associate_part_ass.h"
-#include "../associate_mesh_ass.h"
-
+    integer, pointer :: mype
+    mype => partit%mype
 
     ! ===========================================================================
     ! VARIABLE DECLARATIONS AND INITIALIZATION

--- a/recom_sms.F90
+++ b/recom_sms.F90
@@ -7,7 +7,7 @@ subroutine REcoM_sms(n,Nn,state,thick,recipthick,SurfSR,sms,Temp, Sali_depth &
         , OmegaC_watercolumn                                                 &
         , kspc_watercolumn                                                   &
         , rhoSW_watercolumn                                                  &
-        , Loc_slp, zF, PAR, Lond, Latd, ice, dynamics, tracers, partit, mesh)
+        , Loc_slp, zF, PAR, Lond, Latd, partit, mesh)
 
     use recom_declarations
     use recom_locvar
@@ -19,18 +19,12 @@ subroutine REcoM_sms(n,Nn,state,thick,recipthick,SurfSR,sms,Temp, Sali_depth &
     use g_clock, only: daynew
     use g_config, only: dt, wp, kappa, mstep
     use MOD_MESH, only: t_mesh, sparse_matrix
-    use MOD_TRACER, only: t_tracer
-    use MOD_DYN, only: t_dyn
-    USE MOD_ICE, only: t_ice
     USE MOD_PARTIT, only: t_partit, com_struct
     use mvars, only: vars_sprac
 
     implicit none
-    type(t_dyn)   , intent(inout), target :: dynamics
-    type(t_tracer), intent(inout), target :: tracers
     type(t_partit), intent(inout), target :: partit
     type(t_mesh)  , intent(inout), target :: mesh
-    type(t_ice)   , intent(inout), target :: ice
 
     integer, intent(in)                                     :: Nn                   !< Total number of nodes in the vertical
     real(kind=8),dimension(mesh%nl-1,bgc_num),intent(inout) :: state                !< ChlA conc in phytoplankton [mg/m3]

--- a/recom_sms.F90
+++ b/recom_sms.F90
@@ -15,23 +15,15 @@ subroutine REcoM_sms(n,Nn,state,thick,recipthick,SurfSR,sms,Temp, Sali_depth &
     use recom_config
     use recoM_ciso
     use recom_extra
-    use g_clock
 
-    use g_config
-    use MOD_MESH
-    use MOD_TRACER
-    use MOD_DYN
-    USE MOD_ICE
-    use o_ARRAYS
-    use o_PARAM
-    USE MOD_PARTIT
-    USE MOD_PARSUP
-
-    use g_forcing_arrays
-    use g_comm_auto
-    use mvars
-    use mdepth2press                                   
-    use gsw_mod_toolbox, only: gsw_sa_from_sp,gsw_ct_from_pt,gsw_rho
+    use g_clock, only: daynew
+    use g_config, only: dt, wp, kappa, mstep
+    use MOD_MESH, only: t_mesh, sparse_matrix
+    use MOD_TRACER, only: t_tracer
+    use MOD_DYN, only: t_dyn
+    USE MOD_ICE, only: t_ice
+    USE MOD_PARTIT, only: t_partit, com_struct
+    use mvars, only: vars_sprac
 
     implicit none
     type(t_dyn)   , intent(inout), target :: dynamics
@@ -7193,4 +7185,3 @@ function iron_chemistry(Fe, totalLigand, ligandStabConst)
 
   return
   end
-

--- a/recom_sms.F90
+++ b/recom_sms.F90
@@ -1,4 +1,4 @@
-subroutine REcoM_sms(n,Nn,state,thick,recipthick,SurfSR,sms,Temp, Sali_depth &
+subroutine REcoM_sms(n,Nn,state,thick,SurfSR,sms,Temp, Sali_depth &
         , CO2_watercolumn                                                    &
         , pH_watercolumn                                                     &
         , pCO2_watercolumn                                                   &
@@ -7,7 +7,7 @@ subroutine REcoM_sms(n,Nn,state,thick,recipthick,SurfSR,sms,Temp, Sali_depth &
         , OmegaC_watercolumn                                                 &
         , kspc_watercolumn                                                   &
         , rhoSW_watercolumn                                                  &
-        , Loc_slp, zF, PAR, Lond, Latd, partit, mesh)
+        , Loc_slp, zF, PAR, Latd, partit, mesh)
 
     use recom_declarations
     use recom_locvar
@@ -31,7 +31,6 @@ subroutine REcoM_sms(n,Nn,state,thick,recipthick,SurfSR,sms,Temp, Sali_depth &
                                                                                     !! should be in instead of inout
 
     real(kind=8),dimension(mesh%nl-1)                       :: thick                !< [m] Vertical distance between two nodes = Thickness 
-    real(kind=8),dimension(mesh%nl-1)                       :: recipthick           !< [1/m] reciprocal of thick
     real(kind=8),intent(in)                                 :: SurfSR               !< [W/m2] ShortWave radiation at surface
 
     real(kind=8),dimension(mesh%nl-1,bgc_num),intent(inout) :: sms                  !< Source-Minus-Sinks term
@@ -70,7 +69,6 @@ subroutine REcoM_sms(n,Nn,state,thick,recipthick,SurfSR,sms,Temp, Sali_depth &
     real(kind=8)                                            :: REcoM_Si_depth(1)
     real(kind=8)                                            :: REcoM_Phos_depth(1)
     real(kind=8),                      intent(in)           :: Latd(1)              ! latitude in degree
-    real(kind=8),                      intent(in)           :: Lond(1)              ! longitude in degree
     real(kind=8)                                            :: mocsy_step_per_day 
 
 ! --- Biogeochemical state variables ---

--- a/recom_sms.F90
+++ b/recom_sms.F90
@@ -1,13 +1,57 @@
-subroutine REcoM_sms(n,Nn,state,thick,SurfSR,sms,Temp, Sali_depth &
-        , CO2_watercolumn                                                    &
-        , pH_watercolumn                                                     &
-        , pCO2_watercolumn                                                   &
-        , HCO3_watercolumn                                                   &
-        , CO3_watercolumn                                                    &
-        , OmegaC_watercolumn                                                 &
-        , kspc_watercolumn                                                   &
-        , rhoSW_watercolumn                                                  &
-        , Loc_slp, zF, PAR, Latd, partit, mesh)
+module recom_sms_module
+    interface
+        subroutine REcoM_sms(n, Nn, state, thick, SurfSR, sms, Temp, Sali_depth, CO2_watercolumn, &
+                             pH_watercolumn, pCO2_watercolumn, HCO3_watercolumn, CO3_watercolumn, &
+                             OmegaC_watercolumn, kspc_watercolumn, rhoSW_watercolumn, Loc_slp,    &
+                             zF, PAR, Latd, daynew, dt, kappa, mstep, MPI_COMM_FESOM, mype,       &
+                             myDim_nod2D, eDim_nod2D, nl, geo_coord_nod2D)
+
+            use recom_declarations
+            use recom_locvar
+            use recom_glovar
+            use recom_config
+            use recoM_ciso
+            use recom_extra
+            use g_config, only: wp
+            use mvars, only: vars_sprac
+
+            implicit none
+
+            integer, intent(in) :: n, daynew, mype, myDim_nod2D, eDim_nod2D, nl, mstep
+            integer, intent(in) :: MPI_COMM_FESOM
+            integer, intent(in) :: Nn                   !< Total number of nodes in the vertical
+
+            real(kind=8),  intent(in) :: SurfSR, dt  !< [W/m2] ShortWave radiation at surface
+            real(kind=8),  intent(in) :: Loc_slp     ![Pa] sea-level pressure
+            real(kind=8),  intent(in) :: Latd(1)     ! latitude in degree
+
+            real(kind=8),  intent(in),    dimension(nl - 1) :: thick           !< [m] Vertical distance between two nodes = Thickness 
+            real(kind=8),  intent(in),    dimension(nl - 1) :: Temp            !< [degrees C] Ocean temperature
+            real(kind=8),  intent(in),    dimension(nl - 1) :: Sali_depth      !< NEW MOCSY Salinity for the whole water column
+            real(kind=8),  intent(in),    dimension(nl)     :: zF              !< [m] Depth of fluxes
+            real(kind=WP), intent(in),    dimension(:,:)    :: geo_coord_nod2D
+
+            real(kind=8),  intent(inout)                             :: kappa
+            real(kind=8),  intent(inout), dimension(nl - 1)          :: CO2_watercolumn      !< [mol/m3]
+            real(kind=8),  intent(inout), dimension(nl - 1)          :: pH_watercolumn       !< on total scale
+            real(kind=8),  intent(inout), dimension(nl - 1)          :: pCO2_watercolumn     !< [uatm]
+            real(kind=8),  intent(inout), dimension(nl - 1)          :: HCO3_watercolumn     !< [mol/m3]
+            real(kind=8),  intent(inout), dimension(nl - 1)          :: CO3_watercolumn      !< [mol/m3]
+            real(kind=8),  intent(inout), dimension(nl - 1)          :: OmegaC_watercolumn   !< calcite saturation state
+            real(kind=8),  intent(inout), dimension(nl - 1)          :: kspc_watercolumn     !< stoichiometric solubility product [mol^2/kg^2]
+            real(kind=8),  intent(inout), dimension(nl - 1)          :: rhoSW_watercolumn    !< in-situ density of seawater [kg/m3]
+            real(kind=8),  intent(inout), dimension(nl - 1)          :: PAR
+            real(kind=8),  intent(inout), dimension(nl - 1, bgc_num) :: state                !< ChlA conc in phytoplankton [mg/m3]
+            real(kind=8),  intent(inout), dimension(nl - 1, bgc_num) :: sms                  !< Source-Minus-Sinks term
+        end subroutine
+    end interface
+end module
+
+subroutine REcoM_sms(n, Nn, state, thick, SurfSR, sms, Temp, Sali_depth, CO2_watercolumn, &
+                     pH_watercolumn, pCO2_watercolumn, HCO3_watercolumn, CO3_watercolumn, &
+                     OmegaC_watercolumn, kspc_watercolumn, rhoSW_watercolumn, Loc_slp,    &
+                     zF, PAR, Latd, daynew, dt, kappa, mstep, MPI_COMM_FESOM, mype,       &
+                     myDim_nod2D, eDim_nod2D, nl, geo_coord_nod2D)
 
     use recom_declarations
     use recom_locvar
@@ -15,61 +59,57 @@ subroutine REcoM_sms(n,Nn,state,thick,SurfSR,sms,Temp, Sali_depth &
     use recom_config
     use recoM_ciso
     use recom_extra
-
-    use g_clock, only: daynew
-    use g_config, only: dt, wp, kappa, mstep
-    use MOD_MESH, only: t_mesh
-    USE MOD_PARTIT, only: t_partit
+    use g_config, only: wp
     use mvars, only: vars_sprac
 
     implicit none
-    type(t_partit), intent(inout), target :: partit
-    type(t_mesh)  , intent(inout), target :: mesh
 
-    integer, intent(in)                                     :: Nn                   !< Total number of nodes in the vertical
-    real(kind=8),dimension(mesh%nl-1,bgc_num),intent(inout) :: state                !< ChlA conc in phytoplankton [mg/m3]
-                                                                                    !! should be in instead of inout
+    integer, intent(in) :: n, daynew, mype, myDim_nod2D, eDim_nod2D, nl, mstep
+    integer, intent(in) :: MPI_COMM_FESOM
+    integer, intent(in) :: Nn                   !< Total number of nodes in the vertical
 
-    real(kind=8),dimension(mesh%nl-1)                       :: thick                !< [m] Vertical distance between two nodes = Thickness 
-    real(kind=8),intent(in)                                 :: SurfSR               !< [W/m2] ShortWave radiation at surface
+    real(kind=8),  intent(in)    :: SurfSR, dt  !< [W/m2] ShortWave radiation at surface
+    real(kind=8),  intent(in)    :: Loc_slp     ![Pa] sea-level pressure
+    real(kind=8),  intent(in)    :: Latd(1)     ! latitude in degree
 
-    real(kind=8),dimension(mesh%nl-1,bgc_num),intent(inout) :: sms                  !< Source-Minus-Sinks term
-    real(kind=8),dimension(mesh%nl-1)        ,intent(in)    :: Temp                 !< [degrees C] Ocean temperature
-    real(kind=8),dimension(mesh%nl-1)        ,intent(in)    :: Sali_depth           !< NEW MOCSY Salinity for the whole water column
+    real(kind=8),  intent(in),    dimension(nl - 1) :: thick           !< [m] Vertical distance between two nodes = Thickness 
+    real(kind=8),  intent(in),    dimension(nl - 1) :: Temp            !< [degrees C] Ocean temperature
+    real(kind=8),  intent(in),    dimension(nl - 1) :: Sali_depth      !< NEW MOCSY Salinity for the whole water column
+    real(kind=8),  intent(in),    dimension(nl)   :: zF              !< [m] Depth of fluxes
+    real(kind=WP), intent(in),    dimension(:,:)  :: geo_coord_nod2D
 
-    Real(kind=8),dimension(mesh%nl-1),intent(inout)         :: CO2_watercolumn      !< [mol/m3]
-    Real(kind=8),dimension(mesh%nl-1),intent(inout)         :: pH_watercolumn       !< on total scale
-    Real(kind=8),dimension(mesh%nl-1),intent(inout)         :: pCO2_watercolumn     !< [uatm]
-    Real(kind=8),dimension(mesh%nl-1),intent(inout)         :: HCO3_watercolumn     !< [mol/m3]
-    Real(kind=8),dimension(mesh%nl-1),intent(inout)         :: CO3_watercolumn      !< [mol/m3]
-    Real(kind=8),dimension(mesh%nl-1),intent(inout)         :: OmegaC_watercolumn   !< calcite saturation state
-    Real(kind=8),dimension(mesh%nl-1),intent(inout)         :: kspc_watercolumn     !< stoichiometric solubility product [mol^2/kg^2]
-    Real(kind=8),dimension(mesh%nl-1),intent(inout)         :: rhoSW_watercolumn    !< in-situ density of seawater [kg/m3]
+    real(kind=8),  intent(inout)                          :: kappa
+    real(kind=8),  intent(inout), dimension(nl - 1)         :: CO2_watercolumn      !< [mol/m3]
+    real(kind=8),  intent(inout), dimension(nl - 1)         :: pH_watercolumn       !< on total scale
+    real(kind=8),  intent(inout), dimension(nl - 1)         :: pCO2_watercolumn     !< [uatm]
+    real(kind=8),  intent(inout), dimension(nl - 1)         :: HCO3_watercolumn     !< [mol/m3]
+    real(kind=8),  intent(inout), dimension(nl - 1)         :: CO3_watercolumn      !< [mol/m3]
+    real(kind=8),  intent(inout), dimension(nl - 1)         :: OmegaC_watercolumn   !< calcite saturation state
+    real(kind=8),  intent(inout), dimension(nl - 1)         :: kspc_watercolumn     !< stoichiometric solubility product [mol^2/kg^2]
+    real(kind=8),  intent(inout), dimension(nl - 1)         :: rhoSW_watercolumn    !< in-situ density of seawater [kg/m3]
+    real(kind=8),  intent(inout), dimension(nl - 1)         :: PAR
+    real(kind=8),  intent(inout), dimension(nl - 1, bgc_num) :: state                !< ChlA conc in phytoplankton [mg/m3]
+    real(kind=8),  intent(inout), dimension(nl - 1, bgc_num) :: sms                  !< Source-Minus-Sinks term
 
-    real(kind=8),dimension(mesh%nl)          ,intent(in)    :: zF                   !< [m] Depth of fluxes
-    real(kind=8),dimension(mesh%nl-1),intent(inout)         :: PAR
+    real(kind=8)                    :: dt_d                 !< Size of time steps [day]
+    real(kind=8)                    :: dt_b                 !< Size of time steps [day]
+    real(kind=8)                    :: dt_sink              !< Size of local time step
 
-    real(kind=8)                                            :: dt_d                 !< Size of time steps [day]
-    real(kind=8)                                            :: dt_b                 !< Size of time steps [day]
-    real(kind=8),dimension(mesh%nl-1)                       :: Sink
-    real(kind=8)                                            :: dt_sink              !< Size of local time step
+    real(kind=8)                    :: recip_hetN_plus      !< MB's addition to heterotrophic respiration
+    real(kind=8)                    :: recip_res_het        !< [day] Reciprocal of respiration by heterotrophs and mortality (loss to detritus)
+    real(kind=8)                    :: Sink_Vel
+    real(kind=8)                    :: aux
+    integer                         :: k,step,ii, idiags
 
-    real(kind=8)                                            :: recip_hetN_plus      !< MB's addition to heterotrophic respiration
-    real(kind=8)                                            :: recip_res_het        !< [day] Reciprocal of respiration by heterotrophs and mortality (loss to detritus)
-    real(kind=8)                                            :: Sink_Vel
-    real(kind=8)                                            :: aux
-    integer                                                 :: k,step,ii, idiags,n
-
-    real(kind=8),                      intent(in)           :: Loc_slp              ![Pa] sea-level pressure
-    real(kind=8)                                            :: Patm_depth(1)
-    real(kind=8)                                            :: REcoM_T_depth(1)     ! MOCSY temperature for the whole water column for mocsy minimum defined as -2
-    real(kind=8)                                            :: REcoM_S_depth(1)
-    real(kind=8)                                            :: REcoM_DIC_depth(1)
-    real(kind=8)                                            :: REcoM_Alk_depth(1)
-    real(kind=8)                                            :: REcoM_Si_depth(1)
-    real(kind=8)                                            :: REcoM_Phos_depth(1)
-    real(kind=8),                      intent(in)           :: Latd(1)              ! latitude in degree
-    real(kind=8)                                            :: mocsy_step_per_day 
+    real(kind=8)                    :: Patm_depth(1)
+    real(kind=8)                    :: REcoM_T_depth(1)     ! MOCSY temperature for the whole water column for mocsy minimum defined as -2
+    real(kind=8)                    :: REcoM_S_depth(1)
+    real(kind=8)                    :: REcoM_DIC_depth(1)
+    real(kind=8)                    :: REcoM_Alk_depth(1)
+    real(kind=8)                    :: REcoM_Si_depth(1)
+    real(kind=8)                    :: REcoM_Phos_depth(1)
+    real(kind=8)                    :: mocsy_step_per_day 
+    real(kind=8), dimension(nl - 1) :: Sink
 
 ! --- Biogeochemical state variables ---
 real(kind=8) :: &
@@ -116,9 +156,6 @@ real(kind=8) :: &
     DetZ2Calc, & ! [mmol/m3] Zooplankton detritus calcite
     MicZooN,   & ! [mmol/m3] Microzooplankton nitrogen
     MicZooC      ! [mmol/m3] Microzooplankton carbon
-
-    integer, pointer :: mype
-    mype => partit%mype
 
     ! ===========================================================================
     ! VARIABLE DECLARATIONS AND INITIALIZATION
@@ -3347,7 +3384,7 @@ real(kind=8) :: &
 
            ! Call detailed krill respiration subroutine
            ! Handles additional physiological processes (e.g., molting, reproduction)
-           call krill_resp(n, daynew, partit%myDim_nod2D, partit%eDim_nod2D, mesh%geo_coord_nod2D)
+           call krill_resp(n, daynew, myDim_nod2D, eDim_nod2D, geo_coord_nod2D)
 
            ! Calculate feeding success modifier
            ! Low feeding rates trigger stress response with elevated respiration
@@ -5250,7 +5287,7 @@ real(kind=8) :: &
                 print*,'grazingFlux_Cocco2: ', grazingFlux_Cocco2
                 print*,'grazingFlux_Cocco3: ', grazingFlux_Cocco3
                 print*,'recipQuota_cocco: ', recipQuota_cocco
-                call par_ex(partit%MPI_COMM_FESOM, partit%mype)
+                call par_ex(MPI_COMM_FESOM, mype)
                 stop
             endif
 


### PR DESCRIPTION
This PR starts the work on removing FESOM dependencies from REcoM. Here dependency separation can be understood as replacing explicit use of data types and subroutines from FESOM with native types and custom subroutines.

The work of this PR touches only REcoM internal subroutines and therefore does not affect the ongoing work with submodule separation in FESOM.

The subroutines which have no dependencies in FESOM anymore will be:

- depth_calculations
- cobeta
- krill_resp
- recom_sms
- recom_forcing
- bio_fluxes
- recom_atbox

Naturally, there will still be implicit dependencies on the way in which FESOM data is laid in the memory. But these are also harder to change and will take more work.