### PR TITLE
Removal of unnecessary explicit interfaces

### DIFF
--- a/recom_atbox.F90
+++ b/recom_atbox.F90
@@ -1,16 +1,5 @@
 module recom_atbox_module
-    interface
-        subroutine recom_atbox(MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D, ulevels_nod2D, areasvol, dt)
-            use recom_declarations, only: wp
-
-            integer,       intent(in) :: MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D
-            real(kind=WP), intent(in)                 :: dt
-            integer,       intent(in), dimension(:)   :: ulevels_nod2D
-            real(kind=WP), intent(in), dimension(:,:) :: areasvol
-        end subroutine
-    end interface
-end module recom_atbox_module
-
+contains
     subroutine recom_atbox(MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D, ulevels_nod2D, areasvol, dt)
 !     Simple 0-d box model to calculate the temporal evolution of atmospheric CO2.
 !     Initially the box model was part of module recom_ciso. Now it can be run also
@@ -92,3 +81,4 @@ end module recom_atbox_module
 
       return
     end subroutine recom_atbox
+end module recom_atbox_module

--- a/recom_extra.F90
+++ b/recom_extra.F90
@@ -1,48 +1,5 @@
 module recom_extra
-    interface
-        subroutine Depth_calculations(n, nn, wf, zf, thick, recipthick, myDim_nod2D, eDim_nod2D, nl, hnode, zbar_3d_n)
-            use recom_declarations, only: wp
-
-            ! Input parameters
-            integer, intent(in)                        :: n           ! Current node
-            integer, intent(in)                        :: nn	    ! Total number of vertical nodes
-            integer, intent(in)                        :: myDim_nod2D, eDim_nod2D, nl
-            real(kind=WP), intent(in), dimension(:,:)  :: hnode, zbar_3d_n
-
-            ! Output arrays
-            real(kind=8), dimension(nl,6), intent(out) :: wf          ! [m/day] Flux velocities at the border of the control volumes
-            real(kind=8), dimension(nl),   intent(out) :: zf          ! [m] Depth of vertical fluxes
-            real(kind=8), dimension(nl-1), intent(out) :: thick       ! [m] Distance between two nodes = layer thickness
-            real(kind=8), dimension(nl-1), intent(out) :: recipthick  ! [1/m] Reciprocal thickness
-        end subroutine Depth_calculations
-
-        subroutine Cobeta(daynew, ndpyr, myDim_nod2D, eDim_nod2D, geo_coord_nod2D)
-            use recom_declarations, only: wp
-            integer, intent(in)                       :: daynew, ndpyr, myDim_nod2D, eDim_nod2D
-            real(kind=WP), intent(in), dimension(:,:) :: geo_coord_nod2D
-        end subroutine Cobeta
-
-        subroutine krill_resp(n, daynew, myDim_nod2D, eDim_nod2D, geo_coord_nod2D)
-            use recom_declarations, only: wp
-            integer, intent(in)                       :: n, daynew
-            integer, intent(in)                       :: myDim_nod2D, eDim_nod2D
-            real(kind=WP), intent(in), dimension(:,:) :: geo_coord_nod2D
-        end subroutine krill_resp
-
-        subroutine integrate_nod_2D_recom(data, int2D, MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D, ulevels_nod2D, areasvol)
-            use recom_declarations, only: wp
-
-            implicit none
-
-            integer,       intent(in)    :: MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D
-            real(kind=WP), intent(inout) :: int2D
-
-            integer,       intent(in), dimension(:)   :: ulevels_nod2D
-            real(kind=WP), intent(in), dimension(:)   :: data
-            real(kind=WP), intent(in), dimension(:,:) :: areasvol
-        end subroutine
-    end interface
-end module recom_extra
+contains
 
 !===============================================================================
 ! Subroutine for calculating flux-depth and thickness of control volumes
@@ -241,3 +198,5 @@ subroutine integrate_nod_2D_recom(data, int2D, MPI_COMM_FESOM, myDim_nod2D, eDim
     call MPI_Allreduce(lval, int2D, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                        MPI_COMM_FESOM, MPIerr)
 end subroutine integrate_nod_2D_recom
+
+end module recom_extra

--- a/recom_forcing.F90
+++ b/recom_forcing.F90
@@ -1,51 +1,5 @@
 module recom_forcing_module
-    interface
-        subroutine REcoM_Forcing(n, Nn, state, SurfSW, Loc_slp, Temp, Sali, Sali_depth,    &
-                                 CO2_watercolumn, pH_watercolumn, pCO2_watercolumn,        &
-                                 HCO3_watercolumn, CO3_watercolumn, OmegaC_watercolumn,    &
-                                 kspc_watercolumn, rhoSW_watercolumn, PAR, MPI_COMM_FESOM, &
-                                 mype, myDim_nod2D, eDim_nod2D, nl, hnode, zbar_3d_n,      &
-                                 geo_coord_nod2D, daynew, ndpyr, dt, kappa, mstep, rad)
-
-            use recom_declarations
-            use recom_locvar
-            use recom_config
-            use recom_glovar
-            use recom_extra
-            use recom_sms_module
-            use recom_ciso
-
-            implicit none
-
-            integer, intent(in) :: daynew, ndpyr, mype, myDim_nod2D, eDim_nod2D, nl, mstep
-            integer, intent(in) :: MPI_COMM_FESOM, n, Nn         ! Nn -Total number of nodes
-
-            real(kind=8), intent(in)    :: rad
-            real(kind=8), intent(in)    :: Sali              ! Salinity of current surface layer
-            real(kind=8), intent(in)    :: SurfSW        ! [W/m2] ShortWave radiation at surface
-            real(kind=8), intent(in)    :: Loc_slp       ! [Pa] sea-level pressure
-            real(kind=8), intent(inout) :: kappa, dt
-
-            real(kind=8), intent(in), dimension(nl - 1) :: Temp          ! [degrees C] Ocean temperature
-            real(kind=8), intent(in), dimension(nl - 1) :: Sali_depth    ! Salinity for the whole water column
-
-            !!---- Watercolumn carbonate chemistry
-            real(kind=8), intent(inout), dimension(nl - 1) :: CO2_watercolumn
-            real(kind=8), intent(inout), dimension(nl - 1) :: pH_watercolumn
-            real(kind=8), intent(inout), dimension(nl - 1) :: pCO2_watercolumn
-            real(kind=8), intent(inout), dimension(nl - 1) :: HCO3_watercolumn
-            real(kind=8), intent(inout), dimension(nl - 1) :: CO3_watercolumn
-            real(kind=8), intent(inout), dimension(nl - 1) :: OmegaC_watercolumn
-            real(kind=8), intent(inout), dimension(nl - 1) :: kspc_watercolumn
-            real(kind=8), intent(inout), dimension(nl - 1) :: rhoSW_watercolumn
-            real(kind=8), intent(inout), dimension(nl - 1) :: PAR
-
-            real(kind=WP), intent(in),    dimension(:, :) :: hnode, zbar_3d_n
-            real(kind=WP), intent(in),    dimension(:, :) :: geo_coord_nod2D
-            real(kind=8),  intent(inout), dimension(nl - 1, bgc_num) :: state
-        end subroutine recom_forcing
-    end interface
-end module recom_forcing_module
+contains
 
 !===============================================================================
 ! REcoM_Forcing
@@ -427,3 +381,5 @@ endif
 
   end if
 end subroutine REcoM_Forcing
+
+end module recom_forcing_module

--- a/recom_init.F90
+++ b/recom_init.F90
@@ -4,21 +4,7 @@
 !===============================================================================
 ! allocate & initialise arrays for REcoM
 module recom_init_interface
-    interface
-        subroutine recom_init(nl, ulevels_nod2D, nlevels_nod2D, geo_coord_nod2D, Z_3d_n,   &
-                              myDim_nod2d, eDim_nod2D, mype, MPI_COMM_FESOM, myDim_elem2D, &
-                              eDim_elem2D, tracers_info, num_tracers, rad)
-        use recom_glovar, only: tracers_info_type
-        use recom_declarations, only: wp
-        integer,        intent(in)                  :: nl, mydim_nod2d, edim_nod2d, mype, num_tracers
-        integer,        intent(in)                  :: mpi_comm_fesom, mydim_elem2d, edim_elem2d
-        integer,        intent(in), dimension(:)    :: ulevels_nod2d, nlevels_nod2d
-        real(kind=WP), intent(in)                  :: rad
-        real(kind=wp),  intent(in), dimension(:, :) :: geo_coord_nod2d, z_3d_n
-        type(tracers_info_type), intent(in) :: tracers_info
-        end subroutine
-    end interface
-end module
+contains
 !
 !
 !_______________________________________________________________________________
@@ -708,3 +694,5 @@ subroutine recom_init(nl, ulevels_nod2D, nlevels_nod2D, geo_coord_nod2D, Z_3d_n,
             is_coccos=0.0_WP
         endif
     end subroutine recom_init
+
+end module

--- a/recom_main.F90
+++ b/recom_main.F90
@@ -2,55 +2,81 @@
 ! OG
 !===============================================================================
 ! Main REcoM
-module recom_interface
-    interface
-            subroutine recom(ice_data_values, nl, ulevels_nod2D, nlevels_nod2D, hnode,           &
-                             z_3d_n, zbar_3d_n, geo_coord_nod2D, ocean_area, areasvol, myDim_nod2d,      &
-                             eDim_nod2D, mype, MPI_COMM_FESOM, tracers_info, num_tracers, tra_recom_sms, &
-                             npes, sn, rn, s_mpitype_nod2D, r_mpitype_nod2D, s_mpitype_nod3D, r_mpitype_nod3D, &
-                             sPE, rPE, requests, nreq, dt, daynew, month, mstep, ndpyr, yearold, timenew, rad, kappa, &
-                             press_air, u_wind, v_wind, shortwave)
-            use recom_glovar
-            use recom_declarations, only: wp
-
-            integer, intent(in)                              :: nl, myDim_nod2d, eDim_nod2D
-            integer, intent(in)                              :: mype, MPI_COMM_FESOM, num_tracers
-            integer, intent(in)                              :: mstep, daynew, yearold, month, ndpyr
-            integer, intent(in), dimension(:)                :: ulevels_nod2D, nlevels_nod2D
-            real(kind=WP), intent(inout)                     :: dt, kappa, timenew
-            real(kind=WP), intent(in)                        :: ocean_area, rad
-            real(kind=WP), intent(in), dimension(:)          :: ice_data_values, press_air
-            real(kind=WP), intent(in), dimension(:)          :: u_wind, v_wind, shortwave
-            real(kind=WP), intent(in), dimension(:, :)       :: hnode, z_3d_n, zbar_3d_n
-            real(kind=WP), intent(in), dimension(:, :)       :: geo_coord_nod2D, areasvol
-            real(kind=WP), intent(inout), dimension(:, :, :) :: tra_recom_sms
-
-            integer, intent(in)                                 :: sn, rn, npes
-            integer, intent(inout)                              :: nreq
-            integer, intent(in),    dimension(:)                :: sPE, rPE
-            integer, intent(inout), dimension(:)                :: requests
-            integer, intent(in),    dimension(:),       pointer :: s_mpitype_nod2D, r_mpitype_nod2D
-            integer, intent(in),    dimension(:, :, :), pointer :: s_mpitype_nod3D, r_mpitype_nod3D
-
-            type(tracers_info_type), intent(in) :: tracers_info
-        end subroutine
-    end interface
-end module
 
 module bio_fluxes_interface
-    interface
-        subroutine bio_fluxes(alkalinity, MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D, ocean_area, ulevels_nod2D, areasvol)
-            use recom_declarations, only: wp
+contains
 
-            integer, intent(in)               :: MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D
-            integer, intent(in), dimension(:) :: ulevels_nod2D
+! ======================================================================================
+! Alkalinity restoring to climatology
+! ======================================================================================
+subroutine bio_fluxes(alkalinity, MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D, ocean_area, ulevels_nod2D, areasvol)
+    use recom_declarations
+    use recom_locvar
+    use recom_glovar
+    use recom_config
+    use recom_extra, only: integrate_nod_2d_recom
 
-            real(kind=WP), intent(in)                 :: ocean_area
-            real(kind=WP), intent(in), dimension(:,:) :: areasvol
-            real(kind=WP), intent(in), dimension(:,:) :: alkalinity
-      end subroutine
-    end interface
+    implicit none
+
+    integer, intent(in)               :: MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D
+    integer, intent(in), dimension(:) :: ulevels_nod2D
+
+    real(kind=WP), intent(in)                 :: ocean_area
+    real(kind=WP), intent(in), dimension(:,:) :: areasvol
+    real(kind=WP), intent(in), dimension(:,:) :: alkalinity
+
+    integer       :: n, elem, elnodes(3), n1
+    real(kind=WP) :: ralk, net
+
+!___________________________________________________________________
+! on freshwater inflow/outflow or virtual alkalinity:
+  ! 1. In zlevel & zstar the freshwater flux is applied in the update of the
+  ! ssh matrix when solving the continuity equation of vertically
+  ! integrated flow. The alkalinity concentration in the first layer will
+  ! be then adjusted according to the change in volume.
+
+  ! In this case ralk is forced to be zero by setting ref_alk=0. and ref_alk_local=.false.
+
+  ! 2. In cases where the volume of the upper layer is fixed (i.e. linfs)  the freshwater flux
+  ! 'ralk*water_flux(n)' is applied as a virtual alkalinity boundary condition via the vertical
+  ! diffusion operator.
+
+  ! --> ralk*water_flux(n) : virtual alkalinity flux
+  ! virtual alkalinity flux
+
+!  if (use_virt_alk) then ! OG in case of virtual alkalinity flux
+!     ralk=ref_alk
+!     do n=1, myDim_nod2D+eDim_nod2D
+!        if (ref_alk_local) ralk = tracers%data(2+ialk)%values(1, n)
+!        virtual_alk(n)=ralk*water_flux(n)
+!     end do
+!  end if
+
+    !___________________________________________________________________________
+    ! Balance alkalinity restoring to climatology
+    do n=1, myDim_nod2D + eDim_nod2D
+!        relax_alk(n)=surf_relax_Alk * (Alk_surf(n) - tracers%data(2+ialk)%values(1, n))
+!        relax_alk(n)=surf_relax_Alk * (Alk_surf(n) - alkalinity(ulevels_nod2d(n),n)
+        relax_alk(n)=surf_relax_Alk * (Alk_surf(n) - alkalinity(1, n))
+    end do
+
+  ! 2. virtual alkalinity flux
+!  if (use_virt_alk) then ! is already zero otherwise
+!     call integrate_nod(virtual_alk, net, partit, mesh)
+!     virtual_alk=virtual_alk-net/ocean_area
+!  end if
+
+
+  ! 3. restoring to Alkalinity climatology
+    call integrate_nod_2D_recom(relax_alk, net, MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D, ulevels_nod2D, areasvol)
+
+    relax_alk = relax_alk - net / ocean_area  ! at ocean surface layer
+
+end subroutine bio_fluxes
 end module
+
+module recom_interface
+contains
 
 subroutine recom(ice_data_values, nl, ulevels_nod2D, nlevels_nod2D, hnode,           &
                  z_3d_n, zbar_3d_n, geo_coord_nod2D, ocean_area, areasvol, myDim_nod2d,      &
@@ -821,70 +847,4 @@ subroutine recom(ice_data_values, nl, ulevels_nod2D, nlevels_nod2D, hnode,      
 
 end subroutine recom
 
-! ======================================================================================
-! Alkalinity restoring to climatology
-! ======================================================================================
-subroutine bio_fluxes(alkalinity, MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D, ocean_area, ulevels_nod2D, areasvol)
-    use recom_declarations
-    use recom_locvar
-    use recom_glovar
-    use recom_config
-    use recom_extra, only: integrate_nod_2d_recom
-
-    implicit none
-
-    integer, intent(in)               :: MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D
-    integer, intent(in), dimension(:) :: ulevels_nod2D
-
-    real(kind=WP), intent(in)                 :: ocean_area
-    real(kind=WP), intent(in), dimension(:,:) :: areasvol
-    real(kind=WP), intent(in), dimension(:,:) :: alkalinity
-
-    integer       :: n, elem, elnodes(3), n1
-    real(kind=WP) :: ralk, net
-
-!___________________________________________________________________
-! on freshwater inflow/outflow or virtual alkalinity:
-  ! 1. In zlevel & zstar the freshwater flux is applied in the update of the
-  ! ssh matrix when solving the continuity equation of vertically
-  ! integrated flow. The alkalinity concentration in the first layer will
-  ! be then adjusted according to the change in volume.
-
-  ! In this case ralk is forced to be zero by setting ref_alk=0. and ref_alk_local=.false.
-
-  ! 2. In cases where the volume of the upper layer is fixed (i.e. linfs)  the freshwater flux
-  ! 'ralk*water_flux(n)' is applied as a virtual alkalinity boundary condition via the vertical
-  ! diffusion operator.
-
-  ! --> ralk*water_flux(n) : virtual alkalinity flux
-  ! virtual alkalinity flux
-
-!  if (use_virt_alk) then ! OG in case of virtual alkalinity flux
-!     ralk=ref_alk
-!     do n=1, myDim_nod2D+eDim_nod2D
-!        if (ref_alk_local) ralk = tracers%data(2+ialk)%values(1, n)
-!        virtual_alk(n)=ralk*water_flux(n)
-!     end do
-!  end if
-
-    !___________________________________________________________________________
-    ! Balance alkalinity restoring to climatology
-    do n=1, myDim_nod2D + eDim_nod2D
-!        relax_alk(n)=surf_relax_Alk * (Alk_surf(n) - tracers%data(2+ialk)%values(1, n))
-!        relax_alk(n)=surf_relax_Alk * (Alk_surf(n) - alkalinity(ulevels_nod2d(n),n)
-        relax_alk(n)=surf_relax_Alk * (Alk_surf(n) - alkalinity(1, n))
-    end do
-
-  ! 2. virtual alkalinity flux
-!  if (use_virt_alk) then ! is already zero otherwise
-!     call integrate_nod(virtual_alk, net, partit, mesh)
-!     virtual_alk=virtual_alk-net/ocean_area
-!  end if
-
-
-  ! 3. restoring to Alkalinity climatology
-    call integrate_nod_2D_recom(relax_alk, net, MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D, ulevels_nod2D, areasvol)
-
-    relax_alk = relax_alk - net / ocean_area  ! at ocean surface layer
-
-end subroutine bio_fluxes
+end module

--- a/recom_sinking.F90
+++ b/recom_sinking.F90
@@ -1,120 +1,6 @@
-module diff_ver_recom_expl_interface
-  interface
-subroutine diff_ver_recom_expl(nl, ulevels_nod2D, nlevels_nod2D, nod_in_elem2D_num, nod_in_elem2D, &
-                               nlevels, area, areasvol, hnode_new, tracer_id, myDim_nod2d,         &
-                               eDim_nod2D, mype, MPI_COMM_FESOM, dtr_bf, dt)
-        use recom_declarations, only: wp
-        integer,       intent(in)                    :: myDim_nod2d, eDim_nod2D, mype, MPI_COMM_FESOM
-        integer,       intent(in)                    :: nl, tracer_id
-        integer,       intent(in),    dimension(:)   :: ulevels_nod2D, nlevels_nod2D
-        integer,       intent(in),    dimension(:)   :: nod_in_elem2D_num, nlevels
-        integer,       intent(in),    dimension(:,:) :: nod_in_elem2D
-        real(kind=WP), intent(in)                    :: dt
-        real(kind=WP), intent(in),    dimension(:,:) :: area, areasvol, hnode_new
-        real(kind=WP), intent(inout), dimension(:,:) :: dtr_bf
-    end subroutine
-  end interface
-end module
+module recom_sinking
+contains
 
-module ver_sinking_recom_interface
-  interface
-        subroutine ver_sinking_recom(tr_num, nl, ulevels_nod2D, nlevels_nod2D, zbar_3d_n, z_3d_n, &
-                                     nod_in_elem2D_num, nod_in_elem2D, nlevels, area, areasvol,   &
-                                     hnode, hnode_new, tracer_id, tracer_data_values,             &
-                                     myDim_nod2d, vert_sink, dt)
-        use recom_declarations, only: wp
-
-        integer,       intent(in)                    :: tr_num, myDim_nod2d
-        integer,       intent(in)                    :: nl, tracer_id
-        integer,       intent(in),    dimension(:)   :: ulevels_nod2D, nlevels_nod2D
-        integer,       intent(in),    dimension(:)   :: nod_in_elem2D_num, nlevels
-        integer,       intent(in),    dimension(:,:) :: nod_in_elem2D
-        real(kind=WP), intent(in)                    :: dt
-        real(kind=WP), intent(in),    dimension(:,:) :: zbar_3d_n, z_3d_n, area, areasvol, hnode, hnode_new
-        real(kind=WP), intent(in),    dimension(:,:) :: tracer_data_values
-        real(kind=WP), intent(inout), dimension(:,:) :: vert_sink
-    end subroutine
-  end interface
-end module
-
-module ver_sinking_recom_benthos_interface
-  interface
-        subroutine ver_sinking_recom_benthos(tr_num, nl, ulevels_nod2D, nlevels_nod2D, zbar_3d_n, &
-                                             nod_in_elem2D_num, nod_in_elem2D, nlevels, area, tracer_id,  &
-                                             tracer_data_values, myDim_nod2d, str_bf, mype,               &
-                                             MPI_COMM_FESOM, npes, sn, rn, s_mpitype_nod2D,               &
-                                             r_mpitype_nod2D, s_mpitype_nod3D,           &
-                                             r_mpitype_nod3D, sPE, rPE, requests, nreq, dt)
-        use recom_declarations, only: wp
-
-        integer,       intent(in)                    :: tr_num, nl, tracer_id, myDim_nod2D
-        integer,       intent(in)                    :: mype, MPI_COMM_FESOM
-        integer,       intent(in),    dimension(:)   :: ulevels_nod2D, nlevels_nod2D
-        integer,       intent(in),    dimension(:)   :: nod_in_elem2D_num, nlevels
-        integer,       intent(in),    dimension(:,:) :: nod_in_elem2D
-        real(kind=WP), intent(in)                    :: dt
-        real(kind=WP), intent(in),    dimension(:,:) :: zbar_3d_n, area, tracer_data_values
-        real(kind=WP), intent(inout), dimension(:,:) :: str_bf
-
-        ! These should all go into a dedicated REcoM type
-        integer, intent(in)                                 :: sn, rn, npes
-        integer, intent(inout)                              :: nreq
-        integer, intent(in),    dimension(:)                :: sPE, rPE
-        integer, intent(inout), dimension(:)                :: requests
-        integer, intent(in),    dimension(:),       pointer :: s_mpitype_nod2D, r_mpitype_nod2D
-        integer, intent(in),    dimension(:, :, :), pointer :: s_mpitype_nod3D, r_mpitype_nod3D
-    end subroutine
-  end interface
-end module
-
-module ballast_interface
-  interface
-    subroutine ballast(myDim_nod2d, ulevels_nod2D, nlevels_nod2D, &
-                         geo_coord_nod2D, Z_3d_n, tracer_data_values_1, tracer_data_values_2, rad)
-
-      use recom_declarations, only: wp
-
-      implicit none
-
-      integer,       intent(in)                  :: myDim_nod2D
-      integer,       intent(in), dimension(:)    :: ulevels_nod2D, nlevels_nod2D
-      real(kind=WP), intent(in)                  :: rad
-      real(kind=WP), intent(in), dimension(:, :) :: geo_coord_nod2D, Z_3d_n
-      real(kind=WP), intent(in), dimension(:, :) :: tracer_data_values_1, tracer_data_values_2
-    end subroutine
-  end interface
-end module
-
-module get_particle_density_interface
-  interface
-    subroutine get_particle_density(num_tracers, myDim_nod2d, eDim_nod2D, nl, ulevels_nod2D, &
-                                    nlevels_nod2D, tracers_info)
-        use recom_declarations, only: wp
-        use recom_glovar, only: tracers_info_type
-
-        implicit none
-
-        integer, intent(in)                 :: myDim_nod2d, eDim_nod2D, nl, num_tracers
-        integer, intent(in), dimension(:)   :: ulevels_nod2D, nlevels_nod2D
-        type(tracers_info_type), intent(in) :: tracers_info
-      end subroutine
-  end interface
-end module
-
-module get_seawater_viscosity_interface
-  interface
-    subroutine get_seawater_viscosity(tr_num, myDim_nod2d, ulevels_nod2D, nlevels_nod2D, &
-                                      tracer_data_values_1, tracer_data_values_2)
-        use recom_config
-        use recom_glovar
-
-        integer,      intent(in)                  :: myDim_nod2d
-        integer,      intent(in), target          :: tr_num
-        real(kind=8), intent(in), dimension(:, :) :: tracer_data_values_1, tracer_data_values_2
-        integer,      intent(in), dimension(:)    :: ulevels_nod2D, nlevels_nod2D
-      end subroutine
-  end interface
-end module
 !===============================================================================
 ! YY: sinking of second detritus adapted from Ozgur's code
 ! but not using recom_det_tracer_id, since
@@ -985,3 +871,5 @@ subroutine get_seawater_viscosity(tr_num, myDim_nod2d, ulevels_nod2D, nlevels_no
     end do
 
 end subroutine get_seawater_viscosity
+
+end module

--- a/recom_sms.F90
+++ b/recom_sms.F90
@@ -1,50 +1,5 @@
 module recom_sms_module
-    interface
-        subroutine REcoM_sms(n, Nn, state, thick, SurfSR, sms, Temp, Sali_depth, CO2_watercolumn, &
-                             pH_watercolumn, pCO2_watercolumn, HCO3_watercolumn, CO3_watercolumn, &
-                             OmegaC_watercolumn, kspc_watercolumn, rhoSW_watercolumn, Loc_slp,    &
-                             zF, PAR, Latd, daynew, dt, kappa, mstep, MPI_COMM_FESOM, mype,       &
-                             myDim_nod2D, eDim_nod2D, nl, geo_coord_nod2D)
-
-            use recom_declarations
-            use recom_locvar
-            use recom_glovar
-            use recom_config
-            use recoM_ciso
-            use recom_extra
-            use mvars, only: vars_sprac
-
-            implicit none
-
-            integer, intent(in) :: n, daynew, mype, myDim_nod2D, eDim_nod2D, nl, mstep
-            integer, intent(in) :: MPI_COMM_FESOM
-            integer, intent(in) :: Nn                   !< Total number of nodes in the vertical
-
-            real(kind=8),  intent(in) :: SurfSR, dt  !< [W/m2] ShortWave radiation at surface
-            real(kind=8),  intent(in) :: Loc_slp     ![Pa] sea-level pressure
-            real(kind=8),  intent(in) :: Latd(1)     ! latitude in degree
-
-            real(kind=8),  intent(in),    dimension(nl - 1) :: thick           !< [m] Vertical distance between two nodes = Thickness
-            real(kind=8),  intent(in),    dimension(nl - 1) :: Temp            !< [degrees C] Ocean temperature
-            real(kind=8),  intent(in),    dimension(nl - 1) :: Sali_depth      !< NEW MOCSY Salinity for the whole water column
-            real(kind=8),  intent(in),    dimension(nl)     :: zF              !< [m] Depth of fluxes
-            real(kind=WP), intent(in),    dimension(:,:)    :: geo_coord_nod2D
-
-            real(kind=8),  intent(inout)                             :: kappa
-            real(kind=8),  intent(inout), dimension(nl - 1)          :: CO2_watercolumn      !< [mol/m3]
-            real(kind=8),  intent(inout), dimension(nl - 1)          :: pH_watercolumn       !< on total scale
-            real(kind=8),  intent(inout), dimension(nl - 1)          :: pCO2_watercolumn     !< [uatm]
-            real(kind=8),  intent(inout), dimension(nl - 1)          :: HCO3_watercolumn     !< [mol/m3]
-            real(kind=8),  intent(inout), dimension(nl - 1)          :: CO3_watercolumn      !< [mol/m3]
-            real(kind=8),  intent(inout), dimension(nl - 1)          :: OmegaC_watercolumn   !< calcite saturation state
-            real(kind=8),  intent(inout), dimension(nl - 1)          :: kspc_watercolumn     !< stoichiometric solubility product [mol^2/kg^2]
-            real(kind=8),  intent(inout), dimension(nl - 1)          :: rhoSW_watercolumn    !< in-situ density of seawater [kg/m3]
-            real(kind=8),  intent(inout), dimension(nl - 1)          :: PAR
-            real(kind=8),  intent(inout), dimension(nl - 1, bgc_num) :: state                !< ChlA conc in phytoplankton [mg/m3]
-            real(kind=8),  intent(inout), dimension(nl - 1, bgc_num) :: sms                  !< Source-Minus-Sinks term
-        end subroutine
-    end interface
-end module
+contains
 
 subroutine REcoM_sms(n, Nn, state, thick, SurfSR, sms, Temp, Sali_depth, CO2_watercolumn, &
                      pH_watercolumn, pCO2_watercolumn, HCO3_watercolumn, CO3_watercolumn, &
@@ -7407,6 +7362,8 @@ real(kind=8) :: &
     end do ! Main time loop ends
 
 end subroutine REcoM_sms
+
+end module
 
 !-------------------------------------------------------------------------------
 ! Function for calculating limiter


### PR DESCRIPTION
This PR removes the explicit interfaces in REcoM code that were either already present or that were introduced with the dependency removal from FESOM.

Since in most places there is no overloading of the subroutines, explicit interfaces are not required.