### PR TITLE
Tracer ids refactoring

### DIFF
--- a/recom_init.F90
+++ b/recom_init.F90
@@ -33,6 +33,8 @@ contains
 
         call initialize_memory(myDim_nod2D + eDim_nod2D, nl, num_tracers)
 
+        call initialize_tracer_ids
+
         ! After reading parecomsetup namelist
         call initialize_tracer_indices
 
@@ -259,6 +261,61 @@ contains
             allocate(lb_flux(node_size, 9), source=0.d0)
         end if
     end subroutine initialize_memory
+
+    subroutine initialize_tracer_ids
+        use recom_declarations, only: tracer_ids
+        use REcoM_config, only: enable_3zoo2det, enable_coccos
+
+        integer :: current_tracer_id, total_tracers
+
+        tracer_ids%phytoplankton_nitrogen     = 1004
+        tracer_ids%phytoplankton_carbon       = 1005
+        tracer_ids%phytoplankton_chlorophyll  = 1006
+        tracer_ids%detrital_nitrogen          = 1007
+        tracer_ids%detrital_carbon            = 1008
+        tracer_ids%heterotroph_nitrogen       = 1009
+        tracer_ids%heterotroph_carbon         = 1010
+        tracer_ids%dissolved_organic_nitrogen = 1011
+        tracer_ids%dissolved_organic_carbon   = 1012
+        tracer_ids%diatom_nitrogen            = 1013
+        tracer_ids%diatom_carbon              = 1014
+        tracer_ids%diatom_chlorophyll         = 1015
+        tracer_ids%diatom_silica              = 1016
+        tracer_ids%detrital_silica            = 1017
+        tracer_ids%iron                       = 1019
+        tracer_ids%phytoplankton_calcite      = 1020
+        tracer_ids%detrital_calcite           = 1021
+
+        current_tracer_id = 1023
+
+        if (enable_3zoo2det) then
+            tracer_ids%macrozooplankton_nitrogen = current_tracer_id
+            tracer_ids%macrozooplankton_carbon = current_tracer_id            + 1
+            tracer_ids%macrozooplankton_detrital_nitrogen = current_tracer_id + 2
+            tracer_ids%macrozooplankton_detrital_carbon = current_tracer_id   + 3
+            tracer_ids%macrozooplankton_detrital_silica = current_tracer_id   + 4
+            tracer_ids%macrozooplankton_detrital_calcite = current_tracer_id  + 5
+
+            current_tracer_id = current_tracer_id + 6
+        end if
+
+        if (enable_coccos) then
+            tracer_ids%coccolithophore_nitrogen = current_tracer_id
+            tracer_ids%coccolithophore_carbon = current_tracer_id      + 1
+            tracer_ids%coccolithophore_chlorophyll = current_tracer_id + 2
+            tracer_ids%phaeocystis_nitrogen = current_tracer_id        + 3
+            tracer_ids%phaeocystis_carbon = current_tracer_id          + 4
+            tracer_ids%phaeocystis_chlorophyll = current_tracer_id     + 5
+
+            current_tracer_id = current_tracer_id + 6
+        end if
+
+        if (enable_3zoo2det) then
+            tracer_ids%microzooplankton_nitrogen = current_tracer_id
+            tracer_ids%microzooplankton_carbon = current_tracer_id + 1
+        end if
+
+    end subroutine initialize_tracer_ids
 
     subroutine initialize_tracer_data(num_tracers, tracers_info)
         use REcoM_glovar, only: tracers_info_type

--- a/recom_init.F90
+++ b/recom_init.F90
@@ -317,6 +317,65 @@ contains
 
     end subroutine initialize_tracer_ids
 
+    function get_tracer_init_value(tracer_id) result(init_value)
+        use recom_declarations, only: tracer_ids, wp
+        use REcoM_config, only: tiny, tiny_chl, chl2N_max, NCmax, chl2N_max_d, NCmax_d, SiCmax, &
+                Redfield
+
+        integer, intent(in) :: tracer_id
+        real(kind=wp) :: init_value
+
+        if (tracer_id == tracer_ids%phytoplankton_nitrogen .or. &
+            tracer_id == tracer_ids%diatom_nitrogen .or. &
+            tracer_id == tracer_ids%coccolithophore_nitrogen .or. &
+            tracer_id == tracer_ids%phaeocystis_nitrogen) then
+
+            init_value = tiny_chl / chl2N_max
+
+        else if (tracer_id == tracer_ids%phytoplankton_carbon .or. &
+                 tracer_id == tracer_ids%diatom_carbon .or. &
+                 tracer_id == tracer_ids%coccolithophore_carbon .or. &
+                 tracer_id == tracer_ids%phaeocystis_carbon) then
+
+            init_value = tiny_chl / chl2N_max / NCmax
+
+        else if (tracer_id == tracer_ids%phytoplankton_chlorophyll .or. &
+                 tracer_id == tracer_ids%diatom_chlorophyll .or. &
+                 tracer_id == tracer_ids%coccolithophore_chlorophyll .or. &
+                 tracer_id == tracer_ids%phaeocystis_chlorophyll) then
+
+            init_value = tiny_chl
+
+        else if (tracer_id == tracer_ids%detrital_nitrogen .or. &
+                 tracer_id == tracer_ids%detrital_carbon .or. &
+                 tracer_id == tracer_ids%heterotroph_nitrogen .or. &
+                 tracer_id == tracer_ids%dissolved_organic_nitrogen .or. &
+                 tracer_id == tracer_ids%dissolved_organic_carbon .or. &
+                 tracer_id == tracer_ids%detrital_silica .or. &
+                 tracer_id == tracer_ids%detrital_calcite .or. &
+                 tracer_id == tracer_ids%macrozooplankton_nitrogen .or. &
+                 tracer_id == tracer_ids%macrozooplankton_detrital_nitrogen .or. &
+                 tracer_id == tracer_ids%macrozooplankton_detrital_carbon .or. &
+                 tracer_id == tracer_ids%macrozooplankton_detrital_silica .or. &
+                 tracer_id == tracer_ids%macrozooplankton_detrital_calcite .or. &
+                 tracer_id == tracer_ids%microzooplankton_nitrogen) then
+
+            init_value = tiny
+
+        else if (tracer_id == tracer_ids%heterotroph_carbon .or. &
+                 tracer_id == tracer_ids%phytoplankton_calcite .or. &
+                 tracer_id == tracer_ids%macrozooplankton_carbon .or. &
+                 tracer_id == tracer_ids%microzooplankton_carbon) then
+
+            init_value = tiny * Redfield
+
+        else if (tracer_id == tracer_ids%diatom_silica) then
+
+            init_value = tiny_chl / chl2N_max_d / NCmax_d / SiCmax
+
+        end if
+    end function get_tracer_init_value
+
     subroutine initialize_tracer_data(num_tracers, tracers_info)
         use REcoM_glovar, only: tracers_info_type
         use REcoM_config, only: tiny, tiny_chl, chl2N_max, NCmax, chl2N_max_d, NCmax_d, SiCmax, &

--- a/recom_init.F90
+++ b/recom_init.F90
@@ -11,16 +11,37 @@ module recom_init_interface
 
 contains
     !
+    !===============================================================================
+    ! Model Configuration Summary
+    !===============================================================================
+    ! Configuration 1: Base model (enable_3zoo2det=F, enable_coccos=F)
+    !   - 2 Phytoplankton: General Phy, Diatoms
+    !   - 1 Zooplankton: Heterotrophs
+    !   - 1 Detritus pool
     !
-    !_______________________________________________________________________________
+    ! Configuration 2: 3Zoo2Det (enable_3zoo2det=T, enable_coccos=F)
+    !   - 2 Phytoplankton: General Phy, Diatoms
+    !   - 3 Zooplankton: Het, Zoo2, Zoo3
+    !   - 2 Detritus pools
+    !
+    ! Configuration 3: Coccos (enable_3zoo2det=F, enable_coccos=T)
+    !   - 4 Phytoplankton: General Phy, Diatoms, Coccos, Phaeo
+    !   - 1 Zooplankton: Heterotrophs
+    !   - 1 Detritus pool
+    !
+    ! Configuration 4: Full model (enable_3zoo2det=T, enable_coccos=T)
+    !   - 4 Phytoplankton: General Phy, Diatoms, Coccos, Phaeo
+    !   - 3 Zooplankton: Het, Zoo2, Zoo3
+    !   - 2 Detritus pools
+    !===============================================================================
     subroutine recom_init(nl, ulevels_nod2D, nlevels_nod2D, geo_coord_nod2D, Z_3d_n, myDim_nod2d, &
             eDim_nod2D, mype, MPI_COMM_FESOM, myDim_elem2D, eDim_elem2D, tracers_info, &
             num_tracers, rad)
 
-        use REcoM_declarations, only: wp
+        use REcoM_declarations, only: wp, tracer_ids
         use REcoM_GloVar, only: tracers_info_type
         use recom_config, only: validate_recom_tracers, initialize_tracer_indices, &
-                validate_tracer_id_sequence
+                validate_tracer_id_sequence, bgc_num
 
         implicit none
 
@@ -30,6 +51,8 @@ contains
         integer, intent(in), dimension(:) :: ulevels_nod2d, nlevels_nod2d
         real(kind=wp), intent(in), dimension(:, :) :: geo_coord_nod2d, z_3d_n
         type(tracers_info_type), intent(in) :: tracers_info
+
+        integer :: i, tracer_id
 
         call initialize_memory(myDim_nod2D + eDim_nod2D, nl, num_tracers)
 
@@ -44,7 +67,21 @@ contains
         ! After reading tracer namelist - validate actual IDs
         call validate_tracer_id_sequence(tracers_info%ids(1:num_tracers), num_tracers, mype)
 
-        call initialize_tracer_data(num_tracers, tracers_info)
+        ! Initializes tracer data
+        do i = num_tracers - bgc_num + 1, num_tracers
+            tracer_id = tracers_info%ids(i)
+
+            !Iron (unit conversion: mol/L => umol/m3)
+            if (tracer_id == tracer_ids%iron) then
+
+                tracers_info%data_pointers(i)%tracer_data(:, :) = &
+                    tracers_info%data_pointers(i)%tracer_data(:, :) * 1.e9
+
+            ! Avoids tracers 1001, 1002, 1018 and 1022
+            else if (tracer_id > 1003 .and. tracer_id /= 1018 .and. tracer_id /= 1022) then
+                tracers_info%data_pointers(i)%tracer_data(:, :) = get_tracer_init_value(tracer_id)
+            end if
+        end do
 
         call mask_hydrothermal_vents(tracers_info, myDim_nod2D, eDim_nod2D, ulevels_nod2D, &
                 nlevels_nod2D, geo_coord_nod2D, Z_3d_n, rad)
@@ -376,54 +413,6 @@ contains
 
         end if
     end function get_tracer_init_value
-
-    subroutine initialize_tracer_data(num_tracers, tracers_info)
-        use recom_declarations, only: tracer_ids
-        use REcoM_glovar, only: tracers_info_type
-        use REcoM_config, only: tiny, tiny_chl, chl2N_max, NCmax, chl2N_max_d, NCmax_d, SiCmax, &
-                Redfield, enable_3zoo2det, enable_coccos, bgc_num
-
-        implicit none
-
-        integer, intent(in) :: num_tracers
-        type(tracers_info_type), intent(in) :: tracers_info
-
-        integer :: i, id
-        !===============================================================================
-        ! Model Configuration Summary
-        !===============================================================================
-        ! Configuration 1: Base model (enable_3zoo2det=F, enable_coccos=F)
-        !   - 2 Phytoplankton: General Phy, Diatoms
-        !   - 1 Zooplankton: Heterotrophs
-        !   - 1 Detritus pool
-        !
-        ! Configuration 2: 3Zoo2Det (enable_3zoo2det=T, enable_coccos=F)
-        !   - 2 Phytoplankton: General Phy, Diatoms
-        !   - 3 Zooplankton: Het, Zoo2, Zoo3
-        !   - 2 Detritus pools
-        !
-        ! Configuration 3: Coccos (enable_3zoo2det=F, enable_coccos=T)
-        !   - 4 Phytoplankton: General Phy, Diatoms, Coccos, Phaeo
-        !   - 1 Zooplankton: Heterotrophs
-        !   - 1 Detritus pool
-        !
-        ! Configuration 4: Full model (enable_3zoo2det=T, enable_coccos=T)
-        !   - 4 Phytoplankton: General Phy, Diatoms, Coccos, Phaeo
-        !   - 3 Zooplankton: Het, Zoo2, Zoo3
-        !   - 2 Detritus pools
-        !===============================================================================
-
-        do i = num_tracers - bgc_num + 1, num_tracers
-            id = tracers_info%ids(i)
-
-            if (id == tracer_ids%iron) then
-                tracers_info%data_pointers(i)%tracer_data(:, :) = tracers_info%data_pointers(i)%&
-                        tracer_data(:, :) * 1.e9
-            else if (id > 1003 .and. id /= 1018 .and. id /= 1022) then
-                tracers_info%data_pointers(i)%tracer_data(:, :) = get_tracer_init_value(id)
-            end if
-        end do
-    end subroutine initialize_tracer_data
 
     subroutine mask_hydrothermal_vents(tracers_info, myDim_nod2D, eDim_nod2D, ulevels_nod2D, &
             nlevels_nod2D, geo_coord_nod2D, Z_3d_n, rad)

--- a/recom_init.F90
+++ b/recom_init.F90
@@ -45,6 +45,7 @@ contains
         call validate_tracer_id_sequence(tracers_info%ids(1:num_tracers), num_tracers, mype)
 
         call initialize_tracer_data(num_tracers, tracers_info)
+
         call mask_hydrothermal_vents(tracers_info, myDim_nod2D, eDim_nod2D, ulevels_nod2D, &
                 nlevels_nod2D, geo_coord_nod2D, Z_3d_n, rad)
         call initialization_diagnostics(tracers_info, myDim_nod2D, ulevels_nod2D, nlevels_nod2D, &
@@ -377,6 +378,7 @@ contains
     end function get_tracer_init_value
 
     subroutine initialize_tracer_data(num_tracers, tracers_info)
+        use recom_declarations, only: tracer_ids
         use REcoM_glovar, only: tracers_info_type
         use REcoM_config, only: tiny, tiny_chl, chl2N_max, NCmax, chl2N_max_d, NCmax_d, SiCmax, &
                 Redfield, enable_3zoo2det, enable_coccos, bgc_num
@@ -414,194 +416,12 @@ contains
         do i = num_tracers - bgc_num + 1, num_tracers
             id = tracers_info%ids(i)
 
-            select case (id)
-
-                !---------------------------------------------------------------------------
-                ! Base Model: 2 Phytoplankton + 1 Zooplankton + 1 Detritus
-                !---------------------------------------------------------------------------
-                ! Skip: DIN, DIC, Alk, DSi and O2 are read from files
-                ! Fe [mol/L] => [umol/m3] Check the units again!
-
-                ! --- Small Phytoplankton
-            case (1004) ! PhyN - Phytoplankton Nitrogen
-                tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl / chl2N_max
-
-            case (1005) ! PhyC - Phytoplankton Carbon
-                tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl / chl2N_max / NCmax
-
-            case (1006) ! PhyChl - Phytoplankton Chlorophyll
-                tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl
-
-                ! --- Detritus (Non-living organic matter) ---
-            case (1007) ! DetN - Detrital Nitrogen
-                tracers_info%data_pointers(i)%tracer_data(:, :) = tiny
-
-            case (1008) ! DetC - Detrital Carbon
-                tracers_info%data_pointers(i)%tracer_data(:, :) = tiny
-
-                ! --- Mesozooplankton (Heterotrophs) ---
-            case (1009) ! HetN - Heterotroph Nitrogen
-                tracers_info%data_pointers(i)%tracer_data(:, :) = tiny
-
-            case (1010) ! HetC - Heterotroph Carbon (using Redfield ratio)
-                tracers_info%data_pointers(i)%tracer_data(:, :) = tiny * Redfield
-
-                ! --- Dissolved Organic Matter ---
-            case (1011) ! DON - Dissolved Organic Nitrogen
-                tracers_info%data_pointers(i)%tracer_data(:, :) = tiny
-
-            case (1012) ! DOC - Dissolved Organic Carbon
-                tracers_info%data_pointers(i)%tracer_data(:, :) = tiny
-
-                ! --- Diatoms ---
-            case (1013) ! DiaN - Diatom Nitrogen
-                tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl / chl2N_max
-
-            case (1014) ! DiaC - Diatom Carbon
-                tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl / chl2N_max / NCmax
-
-            case (1015) ! DiaChl - Diatom Chlorophyll
-                tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl
-
-            case (1016) ! DiaSi - Diatom Silica
-                tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl / chl2N_max_d / NCmax_d &
-                        / SiCmax
-
-            case (1017) ! DetSi - Detrital Silica
-                tracers_info%data_pointers(i)%tracer_data(:, :) = tiny
-
-                ! --- Iron (micronutrient) ---
-            case (1019) ! Fe - Iron (unit conversion: mol/L => umol/m3)
+            if (id == tracer_ids%iron) then
                 tracers_info%data_pointers(i)%tracer_data(:, :) = tracers_info%data_pointers(i)%&
                         tracer_data(:, :) * 1.e9
-
-                ! --- Calcium Carbonate (Calcite) ---
-            case (1020) ! PhyCalc - Phytoplankton Calcite
-                tracers_info%data_pointers(i)%tracer_data(:, :) = tiny * Redfield
-
-            case (1021) ! DetCalc - Detrital Calcite
-                tracers_info%data_pointers(i)%tracer_data(:, :) = tiny
-
-                !---------------------------------------------------------------------------
-                ! Extended Model: Additional Zooplankton and Detritus (enable_3zoo2det)
-                !---------------------------------------------------------------------------
-
-            case (1023)
-                if (enable_3zoo2det .and. .not.enable_coccos) then
-                    ! Zoo2N - Macrozooplankton Nitrogen
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny
-                else if (enable_coccos .and. .not.enable_3zoo2det) then
-                    ! CoccoN - Coccolithophore Nitrogen
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl / chl2N_max
-                end if
-
-            case (1024)
-                if (enable_3zoo2det .and. .not.enable_coccos) then
-                    ! Zoo2C - Macrozooplankton Carbon
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny * Redfield
-                else if (enable_coccos .and. .not.enable_3zoo2det) then
-                    ! CoccoC - Coccolithophore Carbon
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl / chl2N_max / NCmax
-                end if
-
-            case (1025)
-                if (enable_3zoo2det .and. .not.enable_coccos) then
-                    ! DetZ2N - Macrozooplankton Detrital Nitrogen
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny
-                else if (enable_coccos .and. .not.enable_3zoo2det) then
-                    ! CoccoChl - Coccolithophore Chlorophyll
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl
-                end if
-
-            case (1026)
-                if (enable_3zoo2det .and. .not.enable_coccos) then
-                    ! DetZ2C - Macrozooplankton Detrital Carbon
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny
-                else if (enable_coccos .and. .not.enable_3zoo2det) then
-                    ! PhaeoN - Phaeocystis Nitrogen
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl / chl2N_max
-                end if
-
-            case (1027)
-                if (enable_3zoo2det .and. .not.enable_coccos) then
-                    ! DetZ2Si - Zooplankton 2 Detrital Silica
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny
-                else if (enable_coccos .and. .not.enable_3zoo2det) then
-                    ! PhaeoC - Phaeocystis Carbon
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl / chl2N_max / NCmax
-                end if
-
-            case (1028)
-                if (enable_3zoo2det .and. .not.enable_coccos) then
-                    ! DetZ2Calc - Macrozooplankton Detrital Calcite
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny
-                else if (enable_coccos .and. .not.enable_3zoo2det) then
-                    ! PhaeoChl - Phaeocystis Chlorophyll
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl
-                end if
-
-                !---------------------------------------------------------------------------
-                ! Extended Model: Coccolithophores with 3Zoo2Det
-                !---------------------------------------------------------------------------
-
-            case (1029)
-                if (enable_coccos .and. enable_3zoo2det) then
-                    ! CoccoN - Coccolithophore Nitrogen
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl / chl2N_max
-                else if (enable_3zoo2det .and. .not.enable_coccos) then
-                    ! Zoo3N - Microzooplankton Nitrogen
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny
-                end if
-
-            case (1030)
-                if (enable_coccos .and. enable_3zoo2det) then
-                    ! CoccoC - Coccolithophore Carbon
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl / chl2N_max / NCmax
-                else if (enable_3zoo2det .and. .not.enable_coccos) then
-                    ! Zoo3C - Microzooplankton Carbon
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny * Redfield
-                end if
-
-            case (1031)
-                if (enable_coccos .and. enable_3zoo2det) then
-                    ! CoccoChl - Coccolithophore Chlorophyll
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl
-                end if
-
-            case (1032)
-                if (enable_coccos .and. enable_3zoo2det) then
-                    ! PhaeoN - Phaeocystis Nitrogen
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl / chl2N_max
-                end if
-
-            case (1033)
-                if (enable_coccos .and. enable_3zoo2det) then
-                    ! PhaeoC - Phaeocystis Carbon
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl / chl2N_max / NCmax
-                end if
-
-            case (1034)
-                if (enable_coccos .and. enable_3zoo2det) then
-                    ! PhaeoChl - Phaeocystis Chlorophyll
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny_chl
-                end if
-
-            case (1035)
-                if (enable_coccos .and. enable_3zoo2det) then
-                    ! Zoo3N - Zooplankton 3 Nitrogen
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny
-                end if
-
-            case (1036)
-                if (enable_coccos .and. enable_3zoo2det) then
-                    ! Zoo3C - Zooplankton 3 Carbon
-                    tracers_info%data_pointers(i)%tracer_data(:, :) = tiny * Redfield
-                end if
-
-            case default
-                write(*, *) "REcoM Warning: Unrecognized tracer ID during initialization: ", id
-
-            end select
+            else if (id > 1003 .and. id /= 1018 .and. id /= 1022) then
+                tracers_info%data_pointers(i)%tracer_data(:, :) = get_tracer_init_value(id)
+            end if
         end do
     end subroutine initialize_tracer_data
 

--- a/recom_modules.F90
+++ b/recom_modules.F90
@@ -341,6 +341,63 @@ module REcoM_declarations
     real(kind=wp) :: is_3zoo2det
     real(kind=wp) :: is_coccos
 
+    type :: recom_tracer_ids
+
+        ! --- Small Phytoplankton
+        integer :: phytoplankton_nitrogen
+        integer :: phytoplankton_carbon
+        integer :: phytoplankton_chlorophyll
+
+        ! --- Detritus (Non-living organic matter) ---
+        integer :: detrital_nitrogen
+        integer :: detrital_carbon
+
+        ! --- Mesozooplankton (Heterotrophs) ---
+        integer :: heterotroph_nitrogen
+        integer :: heterotroph_carbon
+
+        ! --- Dissolved Organic Matter ---
+        integer :: dissolved_organic_nitrogen
+        integer :: dissolved_organic_carbon
+
+        ! --- Diatoms ---
+        integer :: diatom_nitrogen
+        integer :: diatom_carbon
+        integer :: diatom_chlorophyll
+        integer :: diatom_silica
+
+        ! --- Detrital Silica ---
+        integer :: detrital_silica
+
+        ! --- --- Iron (micronutrient) ---
+        integer :: iron
+
+        ! --- Calcium Carbonate (Calcite) ---
+        integer :: phytoplankton_calcite
+        integer :: detrital_calcite
+
+        ! --- 3zoo2det extra tracers ---
+        integer :: macrozooplankton_nitrogen
+        integer :: macrozooplankton_carbon
+        integer :: macrozooplankton_detrital_nitrogen
+        integer :: macrozooplankton_detrital_carbon
+        integer :: macrozooplankton_detrital_silica
+        integer :: macrozooplankton_detrital_calcite
+        integer :: microzooplankton_nitrogen
+        integer :: microzooplankton_carbon
+
+        ! --- coccos extra tracers ---
+        integer :: coccolithophore_nitrogen
+        integer :: coccolithophore_carbon
+        integer :: coccolithophore_chlorophyll
+        integer :: phaeocystis_nitrogen
+        integer :: phaeocystis_carbon
+        integer :: phaeocystis_chlorophyll
+
+    end type recom_tracer_ids
+
+    type(recom_tracer_ids) :: tracer_ids
+
 end module REcoM_declarations
 
 !

--- a/recom_sinking.F90
+++ b/recom_sinking.F90
@@ -24,7 +24,7 @@ contains
 
         use recom_g_comm_auto, only: recom_exchange_nod
 
-        use recom_declarations, only: wp
+        use recom_declarations, only: wp, tracer_ids
         use recom_glovar, only: Benthos, Benthos_tr, SinkFlx_tr
 
         use recom_config, only: allow_var_sinking, benthos_num, bottflx_num, ciso, Vdet, VPhy, &
@@ -79,10 +79,10 @@ contains
             ! *******************************************************
 
             if (enable_3zoo2det) then
-                if (tracer_id == 1025 .or. & !idetz2n
-                        tracer_id == 1026 .or. & !idetz2c
-                        tracer_id == 1027 .or. & !idetz2si
-                        tracer_id == 1028) then !idetz2calc
+                if (tracer_id == tracer_ids%macrozooplankton_detrital_nitrogen .or. & !idetz2n
+                    tracer_id == tracer_ids%macrozooplankton_detrital_carbon .or. & !idetz2c
+                    tracer_id == tracer_ids%macrozooplankton_detrital_silica .or. & !idetz2si
+                    tracer_id == tracer_ids%macrozooplankton_detrital_calcite) then !idetz2calc
                     Vben = VDet_zoo2
                 end if
             end if
@@ -108,10 +108,10 @@ contains
             end do
 
             !! * Particulate Organic Nitrogen *
-            if (tracer_id == 1004 .or. & !iphyn
-                    tracer_id == 1007 .or. & !idetn
-                    tracer_id == 1013 .or. & !idian
-                    tracer_id == 1025) then !idetz2n
+            if (tracer_id == tracer_ids%phytoplankton_nitrogen .or. & !iphyn
+                tracer_id == tracer_ids%detrital_nitrogen .or. & !idetn
+                tracer_id == tracer_ids%diatom_nitrogen .or. & !idian
+                tracer_id == tracer_ids%macrozooplankton_detrital_nitrogen) then !idetz2n
                 Benthos(n, 1) = Benthos(n, 1) + add_benthos_2d(n) ![mmol]
 
                 if (use_MEDUSA) then
@@ -131,10 +131,10 @@ contains
             end if
 
             !! * Particulate Organic Carbon *
-            if (tracer_id == 1005 .or. & !iphyc
-                    tracer_id == 1008 .or. & !idetc
-                    tracer_id == 1014 .or. & !idiac
-                    tracer_id == 1026) then !idetz2c
+            if (tracer_id == tracer_ids%phytoplankton_carbon .or. & !iphyc
+                tracer_id == tracer_ids%detrital_carbon .or. & !idetc
+                tracer_id == tracer_ids%diatom_carbon .or. & !idiac
+                tracer_id == tracer_ids%macrozooplankton_detrital_carbon) then !idetz2c
                 Benthos(n, 2) = Benthos(n, 2) + add_benthos_2d(n)
 
                 if (use_MEDUSA) then
@@ -152,9 +152,9 @@ contains
             end if
 
             !! *Particulate Organic Silicon *
-            if (tracer_id == 1016 .or. & !idiasi
-                    tracer_id == 1017 .or. & !idetsi
-                    tracer_id == 1027) then !idetz2si
+            if (tracer_id == tracer_ids%diatom_silica .or. & !idiasi
+                    tracer_id == tracer_ids%detrital_silica .or. & !idetsi
+                    tracer_id == tracer_ids%macrozooplankton_detrital_silica) then !idetz2si
                 Benthos(n, 3) = Benthos(n, 3) + add_benthos_2d(n)
 
                 if (use_MEDUSA) then
@@ -172,9 +172,9 @@ contains
             end if
 
             !! * Cal *
-            if (tracer_id == 1020 .or. & !iphycal
-                    tracer_id == 1021 .or. & !idetcal
-                    tracer_id == 1028) then !idetz2cal
+            if (tracer_id == tracer_ids%phytoplankton_calcite .or. & !iphycal
+                    tracer_id == tracer_ids%detrital_calcite .or. & !idetcal
+                    tracer_id == tracer_ids%macrozooplankton_detrital_calcite) then !idetz2cal
                 Benthos(n, 4) = Benthos(n, 4) + add_benthos_2d(n)
 
                 if (use_MEDUSA) then
@@ -301,7 +301,7 @@ contains
         ! Remineralization from benthos
         ! bottom_flux
 
-        use recom_declarations, only: wp
+        use recom_declarations, only: wp, tracer_ids
         use recom_glovar, only: GloSed, glodecayBenthos
         use recom_config, only: ciso, use_MEDUSA, sedflx_num, redO2C, Fe2N_benthos
 
@@ -434,7 +434,7 @@ contains
             tracer_id, tracer_data_values, myDim_nod2d, vert_sink, dt)
         ! Sinking in water column
 
-        use REcoM_declarations, only: wp
+        use REcoM_declarations, only: wp, tracer_ids
 
         use REcoM_GloVar, only: sinkvel1_tr, sinkvel2_tr, scaling_visc_3D, scaling_density1_3D, &
             scaling_density2_3D
@@ -482,41 +482,41 @@ contains
         ! Groups tracers by functional type and assigns corresponding velocity
 
         ! Detritus tracers (nitrogen, carbon, silicate, calcite)
-        if (tracer_id == 1007 .or. & ! idetn
-                tracer_id == 1008 .or. & ! idetc
-                tracer_id == 1017 .or. & ! idetsi
-                tracer_id == 1021) then ! idetcal
+        if (tracer_id == tracer_ids%detrital_nitrogen .or. & ! idetn
+                tracer_id == tracer_ids%detrital_carbon .or. & ! idetc
+                tracer_id == tracer_ids%detrital_silica .or. & ! idetsi
+                tracer_id == tracer_ids%detrital_calcite) then ! idetcal
             Vsink = VDet
 
             ! Phytoplankton tracers (nitrogen, carbon, chlorophyll)
-        elseif (tracer_id == 1004 .or. & ! iphyn
-                    tracer_id == 1005 .or. & ! iphyc
-                    tracer_id == 1006) then ! ipchl
+        elseif (tracer_id == tracer_ids%phytoplankton_nitrogen .or. & ! iphyn
+                    tracer_id == tracer_ids%phytoplankton_carbon .or. & ! iphyc
+                    tracer_id == tracer_ids%phytoplankton_chlorophyll) then ! ipchl
             Vsink = VPhy
 
             ! Diatom tracers (nitrogen, carbon, silicate, chlorophyll)
-        elseif (tracer_id == 1013 .or. & ! idian
-                    tracer_id == 1014 .or. & ! idiac
-                    tracer_id == 1016 .or. & ! idiasi
-                    tracer_id == 1015) then ! idchl
+        elseif (tracer_id == tracer_ids%diatom_nitrogen .or. & ! idian
+                    tracer_id == tracer_ids%diatom_carbon .or. & ! idiac
+                    tracer_id == tracer_ids%diatom_silica .or. & ! idiasi
+                    tracer_id == tracer_ids%diatom_chlorophyll) then ! idchl
             Vsink = VDia
 
             ! Coccolithophore tracers (nitrogen, carbon, chlorophyll)
         elseif (enable_coccos .and. &
-                    (tracer_id == 1029 .or. & ! icocn
-                    tracer_id == 1030 .or. & ! icocc
-                    tracer_id == 1031)) then ! icchl
+                    (tracer_id == tracer_ids%coccolithophore_nitrogen .or. & ! icocn
+                    tracer_id == tracer_ids%coccolithophore_carbon .or. & ! icocc
+                    tracer_id == tracer_ids%coccolithophore_chlorophyll)) then ! icchl
             Vsink = VCocco
 
             ! Phaeocystis tracers (nitrogen, carbon, chlorophyll)
         elseif (enable_coccos .and. &
-                    (tracer_id == 1032 .or. & ! iphan
-                    tracer_id == 1033 .or. & ! iphac
-                    tracer_id == 1034)) then ! iphachl
+                    (tracer_id == tracer_ids%phaeocystis_nitrogen .or. & ! iphan
+                    tracer_id == tracer_ids%phaeocystis_carbon .or. & ! iphac
+                    tracer_id == tracer_ids%phaeocystis_chlorophyll)) then ! iphachl
             Vsink = VPhaeo
 
             ! Phytoplankton calcite tracer (special case)
-        elseif (tracer_id == 1020) then ! iphycal
+        elseif (tracer_id == tracer_ids%phytoplankton_calcite) then ! iphycal
             if (enable_coccos) then
                 Vsink = VCocco
             else
@@ -525,10 +525,10 @@ contains
 
             ! Zooplankton-2 detritus tracers (nitrogen, carbon, silicate, calcite)
         elseif (enable_3zoo2det .and. &
-                    (tracer_id == 1025 .or. & ! idetz2n
-                    tracer_id == 1026 .or. & ! idetz2c
-                    tracer_id == 1027 .or. & ! idetz2si
-                    tracer_id == 1028)) then ! idetz2calc
+                (tracer_id == tracer_ids%macrozooplankton_detrital_nitrogen .or. & !idetz2n
+                 tracer_id == tracer_ids%macrozooplankton_detrital_carbon .or. & !idetz2c
+                 tracer_id == tracer_ids%macrozooplankton_detrital_silica .or. & !idetz2si
+                 tracer_id == tracer_ids%macrozooplankton_detrital_calcite)) then !idetz2calc
             Vsink = VDet_zoo2
 
         end if
@@ -562,10 +562,10 @@ contains
                             ! Apply ballasting on slow sinking detritus
                             !if (any(recom_sinking_tracer_id == tracer_id(tr_num))) then
 
-                            if (tracer_id == 1007 .or. & !idetn
-                                    tracer_id == 1008 .or. & !idetc
-                                    tracer_id == 1017 .or. & !idetsi
-                                    tracer_id == 1021) then !idetcal
+                            if (tracer_id == tracer_ids%detrital_nitrogen .or. & !idetn
+                                    tracer_id == tracer_ids%detrital_carbon .or. & !idetc
+                                    tracer_id == tracer_ids%detrital_silica .or. & !idetsi
+                                    tracer_id == tracer_ids%detrital_calcite) then !idetcal
                                 Wvel_flux(nz) = w_ref1 * scaling_density1_3D(nz, n) &
                                         * scaling_visc_3D(nz, n)
 
@@ -584,10 +584,10 @@ contains
 
                     !! ---- We assume constant sinking for second detritus
                     if (enable_3zoo2det .and. &
-                            tracer_id == 1025 .or. & !idetz2n
-                            tracer_id == 1026 .or. & !idetz2c
-                            tracer_id == 1027 .or. & !idetz2si
-                            tracer_id == 1028) then !idetz2calc
+                            tracer_id == tracer_ids%macrozooplankton_detrital_nitrogen .or. & !idetz2n
+                            tracer_id == tracer_ids%macrozooplankton_detrital_carbon .or. & !idetz2c
+                            tracer_id == tracer_ids%macrozooplankton_detrital_silica .or. & !idetz2si
+                            tracer_id == tracer_ids%macrozooplankton_detrital_calcite) then !idetz2calc
                         Wvel_flux(nz) = -VDet_zoo2 / SecondsPerDay
 
                         if (use_ballasting) then
@@ -608,9 +608,11 @@ contains
                     end if
 
                     !-1.0d0/SecondsPerDay  !idetcal
-                    if (tracer_id == 1021) Sinkvel1_tr(nz, n, tr_num) = Wvel_flux(nz)
+                    if (tracer_id == tracer_ids%detrital_calcite) Sinkvel1_tr(nz, n, tr_num) = Wvel_flux(nz)
                     if (enable_3zoo2det .and. &
-                        tracer_id == 1028) Sinkvel2_tr(nz, n, tr_num) = Wvel_flux(nz) !idetz2calc
+                        tracer_id == tracer_ids%macrozooplankton_detrital_calcite) then
+                        Sinkvel2_tr(nz, n, tr_num) = Wvel_flux(nz) !idetz2calc
+                    end if
 
                 end do
 
@@ -828,7 +830,7 @@ contains
 
         use recom_config, only: enable_3zoo2det, rho_CaCO3, rho_opal, rho_POC, rho_PON, tiny
         use recom_glovar, only: tracers_info_type, rho_particle1, rho_particle2
-        use recom_declarations, only: wp
+        use recom_declarations, only: wp, tracer_ids
 
         implicit none
 
@@ -865,14 +867,19 @@ contains
 
         ! Below guarantees non-negative tracer field
         do tr_num = 1, num_tracers
-            if (tracers_info%ids(tr_num) == 1008) b1 = max(tiny, tracers_info%data_pointers(tr_num)&
-                    %tracer_data(:, :)) !idetc      ! [mmol m-3] detritus carbon
-            if (tracers_info%ids(tr_num) == 1007) b2 = max(tiny, tracers_info%data_pointers(tr_num)&
-                    %tracer_data(:, :)) !idetn      ! [mmol m-3] detritus nitrogen
-            if (tracers_info%ids(tr_num) == 1017) b3 = max(tiny, tracers_info%data_pointers(tr_num)&
-                    %tracer_data(:, :)) !idetsi     ! [mmol m-3] detritus Si
-            if (tracers_info%ids(tr_num) == 1021) b4 = max(tiny, tracers_info%data_pointers(tr_num)&
-                    %tracer_data(:, :)) !idetcal    ! [mmol m-3] detritus CaCO3
+            if (tracers_info%ids(tr_num) == tracer_ids%detrital_carbon) then
+                !idetc      ! [mmol m-3] detritus carbon
+                b1 = max(tiny, tracers_info%data_pointers(tr_num)%tracer_data(:, :))
+            else if (tracers_info%ids(tr_num) == tracer_ids%detrital_nitrogen) then
+                !idetn      ! [mmol m-3] detritus nitrogen
+                b2 = max(tiny, tracers_info%data_pointers(tr_num)%tracer_data(:, :))
+            else if (tracers_info%ids(tr_num) == tracer_ids%detrital_silica) then
+                !idetsi     ! [mmol m-3] detritus Si
+                b3 = max(tiny, tracers_info%data_pointers(tr_num)%tracer_data(:, :))
+            else if (tracers_info%ids(tr_num) == tracer_ids%detrital_calcite) then
+                !idetcal    ! [mmol m-3] detritus CaCO3
+                b4 = max(tiny, tracers_info%data_pointers(tr_num)%tracer_data(:, :))
+            end if
         end do
 
         do row = 1, myDim_nod2d
@@ -897,14 +904,19 @@ contains
             b4 = 0.0
             aux = 0.0
             do tr_num = 1, num_tracers
-                if (tracers_info%ids(tr_num) == 1026) b1 = max(tiny, tracers_info%data_pointers(&
-                        tr_num)%tracer_data(:, :)) !idetz2c
-                if (tracers_info%ids(tr_num) == 1025) b2 = max(tiny, tracers_info%data_pointers(&
-                        tr_num)%tracer_data(:, :)) !idetz2n
-                if (tracers_info%ids(tr_num) == 1027) b3 = max(tiny, tracers_info%data_pointers(&
-                        tr_num)%tracer_data(:, :)) !idetz2si
-                if (tracers_info%ids(tr_num) == 1028) b4 = max(tiny, tracers_info%data_pointers(&
-                        tr_num)%tracer_data(:, :)) !idetz2calc
+                if (tracers_info%ids(tr_num) == tracer_ids%macrozooplankton_detrital_carbon) then
+                    !idetz2c
+                    b1 = max(tiny, tracers_info%data_pointers(tr_num)%tracer_data(:, :))
+                else if (tracers_info%ids(tr_num) == tracer_ids%macrozooplankton_detrital_nitrogen) then
+                    !idetz2n
+                    b2 = max(tiny, tracers_info%data_pointers(tr_num)%tracer_data(:, :))
+                else if (tracers_info%ids(tr_num) == tracer_ids%macrozooplankton_detrital_silica) then
+                    !idetz2si
+                    b3 = max(tiny, tracers_info%data_pointers(tr_num)%tracer_data(:, :))
+                else if (tracers_info%ids(tr_num) == tracer_ids%macrozooplankton_detrital_calcite) then
+                    !idetz2calc
+                    b4 = max(tiny, tracers_info%data_pointers(tr_num)%tracer_data(:, :))
+                end if
             end do
 
             do row = 1, myDim_nod2d + eDim_nod2D ! myDim is sufficient


### PR DESCRIPTION
This PR introduces a refactoring to the REcoM initialization and other related parts of the code.

It introduces a data structure with named variables to hold tracer ids, which are used in parts of the code to identify the tracers and select specific behavior for them.

This data structure is initialized in recom_init, and the tracer id values can be different according to configuration flags.

Literal tracer id values used in other parts of the code have been exchanged by the named variables in the new data structure.

A new subroutine that takes a tracer id and returns its correct initialization value has also been created. This will facilitate variable initialization in FABM, and simplifies the tracer data initialization code in REcoM itself.