### PR TITLE
feat(recom): add DIC remineralization (DICremin) tracer

### DIFF
--- a/recom_forcing.F90
+++ b/recom_forcing.F90
@@ -36,9 +36,9 @@ contains
 
         use recom_config, only: bgc_num, chl2n_max, chl2n_max_c, chl2n_max_d, chl2n_max_p, ciso, &
                 diags, enable_3zoo2det, enable_coccos, grazing_detritus, ialk, icchl, icocc, &
-                idchl, idiac, idian, idiasi, idic, idin, imiczooc, imiczoon, ioxy, ipchl, iphac, &
-                iphachl, iphan, iphyc, iphyn, isi, ncmax, ncmax_c, ncmax_d, ncmax_p, nmocsy, one, &
-                pa2atm, recom_debug, secondsperday, sicmax, tiny, tiny_chl, icocn
+                idchl, idiac, idian, idiasi, idic, idin, imiczooc, imiczoon, ioxy, idicremin, ipchl, &
+                iphac, iphachl, iphan, iphyc, iphyn, isi, ncmax, ncmax_c, ncmax_d, ncmax_p, nmocsy, &
+                one, pa2atm, recom_debug, secondsperday, sicmax, tiny, tiny_chl, icocn
 
         use recom_ciso, only: alpha_aq_13, alpha_aq_14, alpha_dic_13, alpha_dic_14, alpha_k_13, &
                 alpha_k_14, alpha_p_13, alpha_p_14, alpha_p_dia_13, alpha_p_dia_14, ciso_14, &
@@ -304,6 +304,8 @@ contains
             state(1:nn, imiczoon) = max(tiny, state(1:nn, imiczoon))
             state(1:nn, imiczooc) = max(tiny, state(1:nn, imiczooc))
         end if
+
+        state(1:nn, idicremin) = max(tiny, state(1:nn, idicremin))
 
         if (recom_debug .and. mype == 0) print *, achar(27) // '[36m' // '     --> ciso after' // &
                 ' REcoM_Forcing' // achar(27) // '[0m'

--- a/recom_init.F90
+++ b/recom_init.F90
@@ -114,8 +114,9 @@ contains
                 tracers_info%data_pointers(i)%tracer_data(:, :) = &
                         tracers_info%data_pointers(i)%tracer_data(:, :) * 1.e9
 
-                ! Avoids tracers 1001, 1002, 1003, 1018 and 1022, age tracer 100
-            else if (tracer_id > 1003 .and. tracer_id /= 1018 .and. tracer_id /= 1022) then
+                ! Avoids tracers 1001, 1002, 1003, 1018, 1022 and DICremin (read from gen_ic3d)
+            else if (tracer_id > 1003 .and. tracer_id /= 1018 .and. tracer_id /= 1022 .and. &
+                    tracer_id /= tracer_ids%dic_remineralization) then  ! allowed since call initialize_tracer_ids happens earlier
                 tracers_info%data_pointers(i)%tracer_data(:, :) = get_tracer_init_value(tracer_id)
             end if
         end do
@@ -343,6 +344,9 @@ contains
 
         integer :: current_tracer_id, total_tracers
 
+        tracer_ids%dissolved_inorganic_nitrogen = 1001
+        tracer_ids%dissolved_inorganic_carbon = 1002
+        tracer_ids%alkalinity = 1003
         tracer_ids%phytoplankton_nitrogen = 1004
         tracer_ids%phytoplankton_carbon = 1005
         tracer_ids%phytoplankton_chlorophyll = 1006
@@ -362,6 +366,9 @@ contains
         tracer_ids%phytoplankton_calcite = 1020
         tracer_ids%detrital_calcite = 1021
         tracer_ids%oxygen = 1022
+
+        ! DIC remineralization diagnostic tracer (added by Sina) -- always present, always last
+        tracer_ids%dic_remineralization = 1037
 
         current_tracer_id = 1023
 
@@ -390,6 +397,7 @@ contains
         if (enable_3zoo2det) then
             tracer_ids%microzooplankton_nitrogen = current_tracer_id
             tracer_ids%microzooplankton_carbon = current_tracer_id + 1
+            current_tracer_id = current_tracer_id + 2   ! << required so DICremin doesn't overwrite microzoo_carbon's slot
         end if
 
     end subroutine initialize_tracer_ids

--- a/recom_main.F90
+++ b/recom_main.F90
@@ -113,7 +113,7 @@ contains
 
         use recom_g_comm_auto, only: recom_exchange_nod
 
-        use recom_declarations, only: wp, decaybenthos
+        use recom_declarations, only: wp, decaybenthos, tracer_ids
         use bio_fluxes_interface, only: bio_fluxes
 
         use recom_config, only: benthos_num, bgc_num, ciso, diags, dust_sol, enable_3zoo2det, &
@@ -190,7 +190,7 @@ contains
         ! ======================================================================================
 
         real(kind=wp) :: SW, Loc_slp
-        integer :: tr_num
+        integer :: tr_num, tracer_id
         integer :: n, nzmax
 
         real(kind=wp) :: Sali
@@ -225,6 +225,24 @@ contains
         allocate(CO3_watercolumn(nl - 1), OmegaC_watercolumn(nl - 1), kspc_watercolumn(nl - 1), &
                 rhoSW_watercolumn(nl - 1))
 
+        num_physical_tracers = 2
+
+        n_transit_tracers = 0
+        if (use_transit) then
+            if (l_sf6)   n_transit_tracers = n_transit_tracers + 1
+            if (l_f11)   n_transit_tracers = n_transit_tracers + 1
+            if (l_f12)   n_transit_tracers = n_transit_tracers + 1
+            if (l_r14c)  n_transit_tracers = n_transit_tracers + 1
+            if (l_r39ar) n_transit_tracers = n_transit_tracers + 1
+        end if
+
+        actual_bgc_num = num_tracers - num_physical_tracers
+        if (use_age_tracer) actual_bgc_num = actual_bgc_num - 1
+        if (use_transit) actual_bgc_num = actual_bgc_num - n_transit_tracers
+
+        bgc_start = num_physical_tracers + 1
+        bgc_end   = num_physical_tracers + actual_bgc_num
+
         do_update = .false.
 
         ! ice concentration [0 to 1]
@@ -233,7 +251,8 @@ contains
         ! virtual flux is possible
 
         if (restore_alkalinity) then
-            call bio_fluxes(tracers_info%data_pointers(2 + ialk)%tracer_data(:, :), &
+            !call bio_fluxes(tracers_info%data_pointers(2 + ialk)%tracer_data(:, :), &
+            call bio_fluxes(tracers_info%data_pointers(bgc_start - 1 + ialk)%tracer_data(:, :), &
                     MPI_COMM_FESOM, myDim_nod2D, eDim_nod2D, ocean_area, ulevels_nod2D, areasvol)
         end if
 
@@ -260,23 +279,13 @@ contains
             end if
         end if
 
-        num_physical_tracers = 2
-
-        n_transit_tracers = 0
-        if (use_transit) then
-            if (l_sf6)   n_transit_tracers = n_transit_tracers + 1
-            if (l_f11)   n_transit_tracers = n_transit_tracers + 1
-            if (l_f12)   n_transit_tracers = n_transit_tracers + 1
-            if (l_r14c)  n_transit_tracers = n_transit_tracers + 1
-            if (l_r39ar) n_transit_tracers = n_transit_tracers + 1
-        end if
-
-        actual_bgc_num = num_tracers - num_physical_tracers
-        if (use_age_tracer) actual_bgc_num = actual_bgc_num - 1
-        if (use_transit) actual_bgc_num = actual_bgc_num - n_transit_tracers
-
-        bgc_start = num_physical_tracers + 1
-        bgc_end   = num_physical_tracers + actual_bgc_num
+        ! Resetting DICremin tracer to zero when reaching surface (added by Sina) 
+        do tr_num = 1,num_tracers
+            tracer_id = tracers_info%ids(tr_num)
+            if (tracer_id == tracer_ids%dic_remineralization) then
+                tracers_info%data_pointers(tr_num)%tracer_data(1, :)  = 0.0_WP
+            end if
+        end do
 
         ! ======================================================================================
         !********************************* LOOP STARTS *****************************************
@@ -487,7 +496,8 @@ contains
         ! ======================================================================================
         !************************** EXCHANGE NODAL INFORMATION *********************************
 
-        do tr_num = num_tracers - bgc_num + 1, num_tracers
+        !do tr_num = num_tracers - bgc_num + 1, num_tracers
+        do tr_num = bgc_start, bgc_end
             call recom_exchange_nod(tracers_info%data_pointers(tr_num)%tracer_data(:, :), &
                     npes, sn, rn, MPI_COMM_FESOM, mype, s_mpitype_nod3D, &
                     r_mpitype_nod3D, sPE, rPE, requests, nreq)

--- a/recom_modules.F90
+++ b/recom_modules.F90
@@ -343,6 +343,10 @@ module REcoM_declarations
 
     type :: recom_tracer_ids
 
+        integer :: dissolved_inorganic_nitrogen
+        integer :: dissolved_inorganic_carbon
+        integer :: alkalinity
+
         ! --- Small Phytoplankton
         integer :: phytoplankton_nitrogen
         integer :: phytoplankton_carbon
@@ -379,6 +383,9 @@ module REcoM_declarations
 
         integer :: oxygen
 
+        ! --- DIC remineralization ---
+        integer :: dic_remineralization
+
         ! --- 3zoo2det extra tracers ---
         ! Default -1 sentinel: these are only assigned in initialize_tracer_ids when the
         ! corresponding &parecomsetup flag is on. -1 never matches a real tracer id, so
@@ -392,13 +399,14 @@ module REcoM_declarations
         integer :: microzooplankton_nitrogen = -1
         integer :: microzooplankton_carbon = -1
 
-        ! --- coccos extra tracers ---
+        ! --- coccos and phaeos tracers ---
         integer :: coccolithophore_nitrogen = -1
         integer :: coccolithophore_carbon = -1
         integer :: coccolithophore_chlorophyll = -1
         integer :: phaeocystis_nitrogen = -1
         integer :: phaeocystis_carbon = -1
         integer :: phaeocystis_chlorophyll = -1
+
 
     end type recom_tracer_ids
 
@@ -432,6 +440,8 @@ module recom_config
     integer :: izoo2n = 23, izoo2c = 24, idetz2n = 25, &
             idetz2c = 26, idetz2si = 27, idetz2calc = 28
 
+    integer :: idicremin = 0  ! added by Sina
+
     ! Microzooplankton (third zooplankton group)
     integer :: imiczoon = 0 ! Microzooplankton Nitrogen (set below)
     integer :: imiczooc = 0 ! Microzooplankton Carbon (set below)
@@ -458,8 +468,9 @@ module recom_config
     integer, dimension(8) :: recom_remin_tracer_id = [1001, 1002, 1003, 1018, 1019, 1022, 1302, &
             1402]
 
-    ! OG
-    ! Todo:  Make recom_sinking_tracer_id case sensitive
+! The static declaration integer, dimension(32) :: recom_sinking_tracer_id 
+! must remain size 32 (the full-model case uses all 32 slots), and the = 0 
+! reset before partial fills ensures unused slots are inert.
     integer, dimension(32) :: recom_sinking_tracer_id = [1007, 1008, 1017, 1021, 1004, 1005, 1020, &
             1006, 1013, 1014, 1016, 1015, 1025, 1026, 1027, 1028, 1029, 1030, 1031, 1032, 1033, &
             1034, 1308, 1321, 1305, 1320, 1314, 1408, 1421, 1405, 1420, 1414]
@@ -994,6 +1005,13 @@ contains
     subroutine initialize_tracer_indices()
         implicit none
 
+        ! ---------------------------------------------------------------------------
+        ! Base sinking tracers (always present in all configurations):
+        !   Det1:  DetN(1007), DetC(1008), DetSi(1017), DetCalc(1021)
+        !   Phy:   PhyN(1004), PhyC(1005), PhyCalc(1020), PhyChl(1006)
+        !   Dia:   DiaN(1013), DiaC(1014), DiaSi(1016), DiaChl(1015)
+        ! ---------------------------------------------------------------------------
+
         if (enable_3zoo2det .and. enable_coccos) then
             ! =======================================================================
             ! CASE: 4 phytoplankton + 3 zooplankton + 2 detritus
@@ -1011,14 +1029,42 @@ contains
             imiczoon = 35
             imiczooc = 36
 
-            !        allocate(recom_cocco_tracer_id(3))
+            ! Terrestrial DOC input (when enable_R2OMIP is enabled)
+            idicremin = 37       ! <- DICremin always gets the lower slot
+
+
             recom_cocco_tracer_id = [1029, 1030, 1031]
-
-            !        allocate(recom_phaeo_tracer_id(3))
             recom_phaeo_tracer_id = [1032, 1033, 1034]
-
-            !        allocate(recom_det2_tracer_id(4))
             recom_det2_tracer_id = [1025, 1026, 1027, 1028]
+
+            ! Base(12) + Det2(4) + Zoo2Det2(4) + Cocco(3) + Phaeo(3) + CoccoCalc(2)
+            ! Det1 sinking: 1007,1008,1017,1021
+            ! Phy  sinking: 1004,1005,1020,1006
+            ! Dia  sinking: 1013,1014,1016,1015
+            ! Det2 sinking: 1025,1026,1027,1028  (DetZ2N,DetZ2C,DetZ2Si,DetZ2Calc)
+            ! Zoo2 det:     1308,1321            (via zoo2 sinking tracer IDs)
+            ! Phy  cal:     1305,1320
+            ! Dia  cal:     1314
+            ! Cocco sinking:1029,1030,1031 -> mapped as 1308..? 
+            ! 
+            ! Reconstructing from original array for full model:
+            ! Original: 1007,1008,1017,1021, 1004,1005,1020,1006,
+            !           1013,1014,1016,1015, 1025,1026,1027,1028,
+            !           1029,1030,1031,
+            !           1032,1033,1034,
+            !           1308,1321,1305,1320,
+            !           1314,1408,1421,1405,1420,1414
+
+            recom_sinking_tracer_id      = 0
+            recom_sinking_tracer_id(1:22) = &
+                (/1007, 1008, 1017, 1021, 1004, 1005, 1020, 1006, &
+                  1013, 1014, 1016, 1015, 1025, 1026, 1027, 1028, &
+                  1029, 1030, 1031, 1032, 1033, 1034/)
+            if (ciso) then
+                recom_sinking_tracer_id(23:32) = &
+                    (/1308, 1321, 1305, 1320, &
+                      1314, 1408, 1421, 1405, 1420, 1414/)
+            end if
 
         else if (enable_coccos .and. .not.enable_3zoo2det) then
             ! =======================================================================
@@ -1035,11 +1081,28 @@ contains
             iphac = 27
             iphachl = 28
 
-            !        allocate(recom_cocco_tracer_id(3))
-            recom_cocco_tracer_id = [1023, 1024, 1025]
+            idicremin = 29       ! <- DICremin always gets the lower slot
 
-            !        allocate(recom_phaeo_tracer_id(3))
+            recom_cocco_tracer_id = [1023, 1024, 1025]
             recom_phaeo_tracer_id = [1026, 1027, 1028]
+
+            ! Det1 sinking: 1007,1008,1017,1021
+            ! Phy  sinking: 1004,1005,1020,1006
+            ! Dia  sinking: 1013,1014,1016,1015
+            ! Cocco sinking:1023,1024,1025
+            ! Phaeo sinking:1026,1027,1028
+            ! Ciso-style:   1308,1321,1305,1320,1314,1408,1421,1405,1420,1414
+            ! No Det2, no Zoo2 sinking
+            recom_sinking_tracer_id      = 0
+            recom_sinking_tracer_id(1:18) = &
+                (/1007, 1008, 1017, 1021, 1004, 1005, 1020, 1006, &
+                  1013, 1014, 1016, 1015, 1023, 1024, 1025,        &
+                  1026, 1027, 1028/)
+            if (ciso) then
+                recom_sinking_tracer_id(19:28) = &
+                    (/1308, 1321, 1305, 1320, &
+                      1314, 1408, 1421, 1405, 1420, 1414/)
+            end if
 
         else if (enable_3zoo2det .and. .not.enable_coccos) then
             ! =======================================================================
@@ -1052,8 +1115,26 @@ contains
             imiczoon = 29
             imiczooc = 30
 
-            !        allocate(recom_det2_tracer_id(4))
+            idicremin = 31       ! <- DICremin always gets the lower slot
+
             recom_det2_tracer_id = [1025, 1026, 1027, 1028]
+
+            ! Det1 sinking: 1007,1008,1017,1021
+            ! Phy  sinking: 1004,1005,1020,1006
+            ! Dia  sinking: 1013,1014,1016,1015
+            ! Det2 sinking: 1025,1026,1027,1028
+            ! Ciso-style:   1308,1321,1305,1320,1314,1408,1421,1405,1420,1414
+            ! No Cocco/Phaeo sinking
+            recom_sinking_tracer_id      = 0
+            recom_sinking_tracer_id(1:16) = &
+                (/1007, 1008, 1017, 1021, 1004, 1005, 1020, 1006, &
+                  1013, 1014, 1016, 1015, 1025, 1026, 1027, 1028/)
+            if (ciso) then
+                recom_sinking_tracer_id(17:26) = &
+                    (/1308, 1321, 1305, 1320, &
+                      1314, 1408, 1421, 1405, 1420, 1414/)
+            end if
+
         else
             ! =======================================================================
             ! CASE: 2 phytoplankton + 1 zooplankton + 1 detritus (BASE CONFIGURATION)
@@ -1062,6 +1143,24 @@ contains
             ! Zooplankton: mesozoo only
             ! Detritus: det1 only
             ! (All indices already set to default values)
+
+            idicremin = 23       ! <- DICremin always gets the lower slot
+
+            ! Det1 sinking: 1007,1008,1017,1021
+            ! Phy  sinking: 1004,1005,1020,1006
+            ! Dia  sinking: 1013,1014,1016,1015
+            ! Ciso-style:   1308,1321,1305,1320,1314,1408,1421,1405,1420,1414
+            ! No Det2, no Cocco/Phaeo sinking
+            recom_sinking_tracer_id      = 0
+            recom_sinking_tracer_id(1:12) = &
+                (/1007, 1008, 1017, 1021, 1004, 1005, 1020, 1006, &
+                 1013, 1014, 1016, 1015/)
+            if (ciso) then
+                recom_sinking_tracer_id(13:22) = &
+                    (/1308, 1321, 1305, 1320, &
+                      1314, 1408, 1421, 1405, 1420, 1414/)
+            end if
+
         end if
     end subroutine initialize_tracer_indices
 
@@ -1141,7 +1240,8 @@ contains
             ! Additional phaeocystis: 3 tracers (1032-1034)
             ! Additional microzoo: 2 tracers (1035-1036)
             ! Total: 22 + 4 + 6 + 3 + 2 = 36 (actually 22 + 14 = 36)
-            expected_bgc_num = 36
+            ! Additional DICremin: 1 tracer (1037) (added by Sina)
+            expected_bgc_num = 37
 
         else if (enable_coccos .and. .not.enable_3zoo2det) then
             ! ---------------------------------------------------------------------------
@@ -1151,7 +1251,8 @@ contains
             ! Additional coccos: 3 tracers (1023-1025)
             ! Additional phaeocystis: 3 tracers (1026-1028)
             ! Total: 22 + 6 = 28
-            expected_bgc_num = 28
+            ! Additional DICremin: 1 tracer (1037) (added by Sina)
+            expected_bgc_num = 29
 
         else if (enable_3zoo2det .and. .not.enable_coccos) then
             ! ---------------------------------------------------------------------------
@@ -1162,14 +1263,16 @@ contains
             ! Additional det2: 4 tracers (1025-1028)
             ! Additional microzoo: 2 tracers (1029-1030)
             ! Total: 22 + 8 = 30
-            expected_bgc_num = 30
+            ! Additional DICremin: 1 tracer (1037) (added by Sina)
+            expected_bgc_num = 31
 
         else
             ! ---------------------------------------------------------------------------
             ! Configuration 1: Base model (2 phyto + 1 zoo + 1 detritus)
             ! ---------------------------------------------------------------------------
             ! Base: 22 tracers (1001-1022)
-            expected_bgc_num = 22
+            ! Additional DICremin: 1 tracer (1037) (added by Sina)
+            expected_bgc_num = 23
 
         end if
 
@@ -1220,6 +1323,7 @@ contains
             expected_tracer_ids(bgc_offset + 12) = 1034 ! PhaeoChl
             expected_tracer_ids(bgc_offset + 13) = 1035 ! Zoo3N
             expected_tracer_ids(bgc_offset + 14) = 1036 ! Zoo3C
+            expected_tracer_ids(bgc_offset + 15) = 1037 ! DIC remin (added by Sina)
 
         else if (enable_coccos .and. .not.enable_3zoo2det) then
             ! Coccos only: base + 1023-1028 (coccos+phaeo)
@@ -1229,6 +1333,7 @@ contains
             expected_tracer_ids(bgc_offset + 4) = 1026 ! PhaeoN
             expected_tracer_ids(bgc_offset + 5) = 1027 ! PhaeoC
             expected_tracer_ids(bgc_offset + 6) = 1028 ! PhaeoChl
+            expected_tracer_ids(bgc_offset + 7) = 1037 ! DIC remin (added by Sina)
 
         else if (enable_3zoo2det .and. .not.enable_coccos) then
             ! 3Zoo2Det only: base + 1023-1030 (zoo2+det2+zoo3)
@@ -1240,9 +1345,14 @@ contains
             expected_tracer_ids(bgc_offset + 6) = 1028 ! DetZ2Calc
             expected_tracer_ids(bgc_offset + 7) = 1029 ! Zoo3N
             expected_tracer_ids(bgc_offset + 8) = 1030 ! Zoo3C
-        end if
+            expected_tracer_ids(bgc_offset + 9) = 1037 ! DIC remin (added by Sina)
 
-        ! else: base configuration only needs tracers 1, 2, 1001-1022
+        else
+       
+            ! else: base configuration only needs tracers 1, 2, 1001-1022
+            expected_tracer_ids(bgc_offset + 1) = 1037 ! add DIC remin tracer to base BGC tracers (added by Sina)
+
+        end if
 
         ! ---- Age tracer (ID=100): appended immediately after the last BGC slot -----
         slot = n_base_physical + expected_bgc_num + 1
@@ -1324,17 +1434,19 @@ contains
                 write(*, *) '  Difference:           ', actual_bgc_num - expected_bgc_num
                 write(*, *) ''
                 write(*, *) 'Required tracer IDs for current configuration:'
-                write(*, *) '  Base tracers (always):  1001-1022 (22 tracers)'
+                write(*, *) '  Base tracers (always):  1001-1022 (22 tracers) + 1037 (DICremin)'
 
                 if (enable_3zoo2det .and. .not.enable_coccos) then
                     write(*, *) '  3Zoo2Det extension:     1023-1030 (8 tracers)'
                     write(*, *) '    - Zoo2N, Zoo2C:       1023-1024'
                     write(*, *) '    - DetZ2 pool:         1025-1028'
                     write(*, *) '    - MicZooN, MicZooC:   1029-1030'
+                    write(*, *) '  DICremin:               1037     ' ! added by Sina
                 else if (enable_coccos .and. .not.enable_3zoo2det) then
                     write(*, *) '  Coccos extension:       1023-1028 (6 tracers)'
                     write(*, *) '    - CoccoN, C, Chl:     1023-1025'
                     write(*, *) '    - PhaeoN, C, Chl:     1026-1028'
+                    write(*, *) '  DICremin:               1037     ' ! added by Sina
                 else if (enable_3zoo2det .and. enable_coccos) then
                     write(*, *) '    - Zoo2N, Zoo2C:       1023-1024'
                     write(*, *) '  3Zoo2Det extension:     1025-1028 (4 tracers for det2)'
@@ -1342,6 +1454,7 @@ contains
                     write(*, *) '    - CoccoN, C, Chl:     1029-1031'
                     write(*, *) '    - PhaeoN, C, Chl:     1032-1034'
                     write(*, *) '  MicroZoo extension:     1035-1036 (2 tracers)'
+                    write(*, *) '  DICremin:               1037     ' ! added by Sina
                 end if
 
                 write(*, *) ''
@@ -1448,11 +1561,13 @@ contains
                 write(*, *) '  - Coccos uses:       1029-1031'
                 write(*, *) '  - Phaeocystis uses:  1032-1034'
                 write(*, *) '  - Microzooplankton:  1035-1036'
+                write(*, *) '  - DIC remin:         1037     ' ! added by Sina
                 write(*, *) ''
             else if (enable_coccos .and. .not.enable_3zoo2det) then
                 write(*, *) 'IMPORTANT for COCCOS-ONLY configuration:'
                 write(*, *) '  - Coccos uses:       1023-1025 (NOT 1029-1031)'
                 write(*, *) '  - Phaeocystis uses:  1026-1028 (NOT 1032-1034)'
+                write(*, *) '  - DIC remin:         1037     ' ! added by Sina
                 write(*, *) '  - Tracers 1029+ are NOT used in this configuration'
                 write(*, *) ''
             else if (enable_3zoo2det .and. .not.enable_coccos) then
@@ -1460,11 +1575,12 @@ contains
                 write(*, *) '  - Zoo2 uses:         1023-1024'
                 write(*, *) '  - Det2 pool uses:    1025-1028'
                 write(*, *) '  - Microzoo uses:     1029-1030 (NOT 1035-1036)'
+                write(*, *) '  - DIC remin:         1037     ' ! added by Sina
                 write(*, *) '  - Tracers 1031+ are NOT used in this configuration'
                 write(*, *) ''
             else
                 write(*, *) 'IMPORTANT for BASE configuration:'
-                write(*, *) '  - Only tracers 1-2, 1001-1022 should be present'
+                write(*, *) '  - Only tracers 1-2, 1001-1022 and 1037 should be present' ! 1037 added by Sina
                 write(*, *) '  - Tracers 1023+ are NOT used in base configuration'
                 write(*, *) ''
             end if
@@ -1560,13 +1676,17 @@ contains
 
         ! ---- derive local BGC count (same logic as validate_recom_tracers) --------
         if (enable_3zoo2det .and. enable_coccos) then
-            bgc_num_local = 36
+            ! Additional DICremin: 1 tracer (1037) (added by Sina)
+            bgc_num_local = 37
         else if (enable_coccos .and. .not. enable_3zoo2det) then
-            bgc_num_local = 28
+            ! Additional DICremin: 1 tracer (1037) (added by Sina)
+            bgc_num_local = 29
         else if (enable_3zoo2det .and. .not. enable_coccos) then
-            bgc_num_local = 30
+            ! Additional DICremin: 1 tracer (1037) (added by Sina)
+            bgc_num_local = 31
         else
-            bgc_num_local = 22
+            ! Additional DICremin: 1 tracer (1037) (added by Sina)
+            bgc_num_local = 23
         end if
 
         ! num_physical_tracers (global) is just T,S in the new layout
@@ -1591,12 +1711,19 @@ contains
             expected_ids(n_base_physical+23:n_base_physical+28) = [1023, 1024, 1025, 1026, 1027, 1028]
             expected_ids(n_base_physical+29:n_base_physical+34) = [1029, 1030, 1031, 1032, 1033, 1034]
             expected_ids(n_base_physical+35:n_base_physical+36) = [1035, 1036]
+            expected_ids(n_base_physical+37)    = 1037 ! DICremin, added by Sina
 
         else if (enable_coccos .and. .not.enable_3zoo2det) then
             expected_ids(n_base_physical+23:n_base_physical+28) = [1023, 1024, 1025, 1026, 1027, 1028]
+            expected_ids(n_base_physical+29)    = 1037 ! DICremin, added by Sina
 
         else if (enable_3zoo2det .and. .not.enable_coccos) then
             expected_ids(n_base_physical+23:n_base_physical+30) = [1023, 1024, 1025, 1026, 1027, 1028, 1029, 1030]
+            expected_ids(n_base_physical+31)    = 1037 ! DICremin, added by Sina
+
+        else
+            ! Base configuration
+            expected_ids(n_base_physical+23)    = 1037 ! DICremin, added by Sina
         end if
 
         ! ---- age tracer (running slot, right after BGC) ----------------------------

--- a/recom_sms.F90
+++ b/recom_sms.F90
@@ -205,7 +205,8 @@ contains
                 PhyCalc, & ! [mmol/m3] Phytoplankton calcite
                 DetCalc, & ! [mmol/m3] Detrital calcite
                 FreeFe, & ! [mmol/m3] Free iron
-                O2 ! [mmol/m3] Dissolved oxygen
+                O2, & ! [mmol/m3] Dissolved oxygen
+                DICremin ! [mmol/m3] Dissolved inorganic carbon remineralization
 
         ! Coccolithophore variables (conditionally used based on namelist)
         real(kind=wp) :: &
@@ -477,7 +478,7 @@ contains
                 call sms_initialize_variables(n, k, state, sms, thick, Temp, Sali_depth, SurfSR, &
                         PAR, kappa, DIN, DIC, Alk, PhyN, PhyC, PhyChl, DetN, DetC, HetN, HetC, &
                         DON, EOC, DiaN, DiaC, DiaChl, DiaSi, DetSi, Si, Fe, PhyCalc, DetCalc, &
-                        FreeFe, O2, CoccoN, CoccoC, CoccoChl, PhaeoN, PhaeoC, PhaeoChl, Zoo2N, &
+                        FreeFe, O2, DICremin, CoccoN, CoccoC, CoccoChl, PhaeoN, PhaeoC, PhaeoChl, Zoo2N, &
                         Zoo2C, DetZ2N, DetZ2C, DetZ2Si, DetZ2Calc, MicZooN, MicZooC, &
                         recip_hetN_plus, REcoM_T_depth, REcoM_S_depth, REcoM_DIC_depth, &
                         REcoM_Alk_depth, REcoM_Si_depth, REcoM_Phos_depth)
@@ -3782,6 +3783,7 @@ contains
         !       with species-specific parameters reflecting different sensitivities
         !-------------------------------------------------------------------------------
 
+        ! OG Why do we keep h_depth ? Do we use proton concentration somewhere in the code?
         ! Convert pH to proton concentration for calculations
         ! pH = -log10[H+], therefore [H+] = 10^(-pH)
         h_depth(1) = 10.d0 ** (-ph_depth(1))

--- a/recom_sms_init.F90
+++ b/recom_sms_init.F90
@@ -7,7 +7,7 @@ contains
 
     subroutine sms_initialize_variables(n, k, state, sms, thick, Temp, Sali_depth, SurfSR, PAR, &
             kappa, DIN, DIC, Alk, PhyN, PhyC, PhyChl, DetN, DetC, HetN, HetC, DON, EOC, DiaN, &
-            DiaC, DiaChl, DiaSi, DetSi, Si, Fe, PhyCalc, DetCalc, FreeFe, O2, CoccoN, CoccoC, &
+            DiaC, DiaChl, DiaSi, DetSi, Si, Fe, PhyCalc, DetCalc, FreeFe, O2, DICremin, CoccoN, CoccoC, &
             CoccoChl, PhaeoN, PhaeoC, PhaeoChl, Zoo2N, Zoo2C, DetZ2N, DetZ2C, DetZ2Si, DetZ2Calc, &
             MicZooN, MicZooC, recip_hetN_plus, REcoM_T_depth, REcoM_S_depth, REcoM_DIC_depth, &
             REcoM_Alk_depth, REcoM_Si_depth, REcoM_Phos_depth)
@@ -27,7 +27,7 @@ contains
                 chl2n_max_p, enable_3zoo2det, enable_coccos, expon_cocco, expon_d, expon_phy, &
                 grazing_detritus, ialk, icchl, icocc, icocn, idchl, idetc, idetcal, idetn, &
                 idetz2c, idetz2calc, idetz2n, idetz2si, idiac, idian, idiasi, idic, idin, &
-                idoc, idon, ife, ihetc, ihetn, imiczooc, imiczoon, ioxy, ipchl, iphac, iphachl, &
+                idoc, idon, ife, ihetc, ihetn, imiczooc, imiczoon, ioxy, idicremin, ipchl, iphac, iphachl, &
                 iphan, iphyc, iphyn, isi, izoo2c, izoo2n, k_o2_remin, k_w, ncmax, ncmax_c, &
                 ncmax_d, ncmax_p, ncmin, ncmin_c, ncmin_d, ncmin_p, o2dep_remin, one, ord_cocco, &
                 recom_tref, res_het, sicmax, t1_zoo2, t2_zoo2, t3_zoo2, t4_zoo2, tiny, tiny_chl, &
@@ -58,8 +58,8 @@ contains
 
         real(kind=wp), intent(inout) :: DIN, DIC, Alk, PhyN, PhyC, PhyChl, DetN, DetC, HetN, HetC, &
                 DON, EOC, DiaN, DiaC, DiaChl, DiaSi, DetSi, Si, Fe, PhyCalc, DetCalc, FreeFe, O2, &
-                CoccoN, CoccoC, CoccoChl, PhaeoN, PhaeoC, PhaeoChl, Zoo2N, Zoo2C, DetZ2N, DetZ2C, &
-                DetZ2Si, DetZ2Calc, MicZooN, MicZooC, recip_hetN_plus
+                DICremin, CoccoN, CoccoC, CoccoChl, PhaeoN, PhaeoC, PhaeoChl, Zoo2N, Zoo2C, DetZ2N, &
+                DetZ2C, DetZ2Si, DetZ2Calc, MicZooN, MicZooC, recip_hetN_plus
 
         real(kind=wp), intent(inout), dimension(1) :: REcoM_T_depth, REcoM_S_depth, REcoM_DIC_depth&
                 , &
@@ -90,11 +90,13 @@ contains
         !   DIC : Dissolved inorganic carbon (CO2 + HCO3- + CO3--) [mmolC m-3]
         !   ALK : Total alkalinity [meq m-3]
         !   O2  : Dissolved oxygen [mmolO2 m-3]
+        !   DICremin : Dissolved inorganic carbon remineralization [mmolC m-3]
         !-----------------------------------------------------------------------
 
         DIC = max(tiny, state(k, idic) + sms(k, idic))
         ALK = max(tiny, state(k, ialk) + sms(k, ialk))
         O2 = max(tiny, state(k, ioxy) + sms(k, ioxy))
+        DICremin = max(tiny, state(k, idicremin) + sms(k, idicremin))
 
         !-----------------------------------------------------------------------
         ! DISSOLVED ORGANIC MATTER

--- a/recom_sms_update.F90
+++ b/recom_sms_update.F90
@@ -9,7 +9,7 @@ contains
 
     subroutine sms_update_tracer_scalars(n, k, state, sms, thick, Temp, Sali_depth, SurfSR, PAR, &
             kappa, DIN, DIC, Alk, PhyN, PhyC, PhyChl, DetN, DetC, HetN, HetC, DON, EOC, DiaN, &
-            DiaC, DiaChl, DiaSi, DetSi, Si, Fe, PhyCalc, DetCalc, FreeFe, O2, CoccoN, CoccoC, &
+            DiaC, DiaChl, DiaSi, DetSi, Si, Fe, PhyCalc, DetCalc, FreeFe, O2, DICremin, CoccoN, CoccoC, &
             CoccoChl, PhaeoN, PhaeoC, PhaeoChl, Zoo2N, Zoo2C, DetZ2N, DetZ2C, DetZ2Si, DetZ2Calc, &
             MicZooN, MicZooC, recip_hetN_plus, REcoM_T_depth, REcoM_S_depth, REcoM_DIC_depth, &
             REcoM_Alk_depth, REcoM_Si_depth, REcoM_Phos_depth)
@@ -29,7 +29,7 @@ contains
                 chl2n_max_p, enable_3zoo2det, enable_coccos, expon_cocco, expon_d, expon_phy, &
                 grazing_detritus, ialk, icchl, icocc, icocn, idchl, idetc, idetcal, idetn, &
                 idetz2c, idetz2calc, idetz2n, idetz2si, idiac, idian, idiasi, idic, idin, idoc, &
-                idon, ife, ihetc, ihetn, imiczooc, imiczoon, ioxy, ipchl, iphac, iphachl, iphan, &
+                idon, ife, ihetc, ihetn, imiczooc, imiczoon, ioxy, idicremin, ipchl, iphac, iphachl, iphan, &
                 iphyc, iphyn, isi, izoo2c, izoo2n, k_o2_remin, k_w, ncmax, ncmax_c, ncmax_d, &
                 ncmax_p, ncmin, ncmin_c, ncmin_d, ncmin_p, o2dep_remin, one, ord_cocco, ord_d, &
                 ord_phy, recom_tref, res_het, sicmax, t1_zoo2, t2_zoo2, t3_zoo2, t4_zoo2, tiny, &
@@ -60,8 +60,8 @@ contains
 
         real(kind=wp), intent(inout) :: DIN, DIC, Alk, PhyN, PhyC, PhyChl, DetN, DetC, HetN, HetC, &
                 DON, EOC, DiaN, DiaC, DiaChl, DiaSi, DetSi, Si, Fe, PhyCalc, DetCalc, FreeFe, O2, &
-                CoccoN, CoccoC, CoccoChl, PhaeoN, PhaeoC, PhaeoChl, Zoo2N, Zoo2C, DetZ2N, DetZ2C, &
-                DetZ2Si, DetZ2Calc, MicZooN, MicZooC, recip_hetN_plus
+                DICremin, CoccoN, CoccoC, CoccoChl, PhaeoN, PhaeoC, PhaeoChl, Zoo2N, Zoo2C, DetZ2N, &
+                DetZ2C, DetZ2Si, DetZ2Calc, MicZooN, MicZooC, recip_hetN_plus
 
         real(kind=wp), intent(inout), dimension(1) :: REcoM_T_depth, REcoM_S_depth, REcoM_DIC_depth&
                 , &
@@ -97,6 +97,7 @@ contains
         DIC = max(tiny, state(k, idic) + sms(k, idic))
         ALK = max(tiny, state(k, ialk) + sms(k, ialk))
         O2 = max(tiny, state(k, ioxy) + sms(k, ioxy))
+        DICremin = max(tiny, state(k, idicremin) + sms(k, idicremin))
 
         !-----------------------------------------------------------------------
         ! DISSOLVED ORGANIC MATTER
@@ -1085,7 +1086,7 @@ contains
                 ihetn, ihetc, izoo2n, izoo2c, imiczoon, imiczooc, &
                 idetn, idetc, idetsi, idetcal, &
                 idetz2n, idetz2c, idetz2si, idetz2calc, &
-                idon, idoc, isi, ife, ioxy, &
+                idon, idoc, isi, ife, ioxy, idicremin, &
                 grazing_detritus, enable_3zoo2det, enable_coccos, &
                 lossn, lossn_d, lossn_c, lossn_p, &
                 lossn_z, lossn_z2, lossn_z3, &
@@ -1184,7 +1185,7 @@ contains
         ! SINKS: Nitrogen Uptake (decreases DIN)
         !---------------------------------------------------------------------------
         ! Phytoplankton assimilation of NO3- and NH4+
-                -N_assim * PhyC & ! Small phytoplankton
+                - N_assim * PhyC & ! Small phytoplankton
                 - N_assim_Dia * DiaC & ! Diatoms
                 - N_assim_Cocco * CoccoC * is_coccos & ! Coccolithophores
                 - N_assim_Phaeo * PhaeoC * is_coccos & ! Phaeocystis
@@ -3049,6 +3050,14 @@ contains
                 ) * redO2C * dt_b + sms(k, ioxy)
         ! Note: redO2C converts carbon-based rates to oxygen equivalents
         !       using the Redfield ratio (typically ~170/122 = 1.39 mol O2/mol C)
+
+        !===============================================================================
+        ! 37. DIC remineralzation tracer to track remineralization as an diagnostics
+        !===============================================================================
+        !   idicremin       : Tracer for remineralization diagnostics (added by Sina)
+        sms(k, idicremin) = (                 &
+            + rho_c1 * arrFunc * O2Func * EOC &
+            ) * dt_b + sms(k,idicremin)
 
         if (ciso) then
 


### PR DESCRIPTION
Introduce a dedicated diagnostic tracer for DIC remineralization ("DICremin", added by Sina) across the REcoM tracer bookkeeping. Its value is read from the initial-condition file via gen_ic3d and is intentionally left untouched by recom_init.

- recom_declarations: add `dic_remineralization` field (default -1) to the `recom_tracer_ids` derived type
- recom_config:
  - add `idicremin` tracer-index variable
  - assign idicremin per configuration in initialize_tracer_indices (23 / 29 / 31 / 37 for base / coccos / 3zoo2det / full model)
  - account for the extra BGC tracer in validate_recom_tracers and validate_tracer_id_sequence (expected_bgc_num, expected tracer id sequence)
- recom_init_interface:
  - initialize_tracer_ids: no longer collision with microzooplankton_carbon's slot
  - recom_init: exclude tracer_ids%dic_remineralization from the get_tracer_init_value initialization loop, since its values come from the IC file rather than a computed default