### PR TITLE
feat(recom): propagate nzmin through BGC forcing chain to support ice…

### DIFF
--- a/recom_extra.F90
+++ b/recom_extra.F90
@@ -12,9 +12,26 @@ module recom_extra
 contains
 
     !===============================================================================
-    ! Subroutine for calculating flux-depth and thickness of control volumes
+    ! Depth_calculations
+    !   Computes layer thicknesses, reciprocal thicknesses, flux-point depths, and
+    !   background sinking-velocity profiles for a single water column at node n.
+    !
+    !   Arguments:
+    !     n      - node index
+    !     nzmin  - top active level (1 for open ocean, >1 for ice-shelf cavity)
+    !     nzmax  - bottom active level (= nlevels_nod2D(n) - 1)
+    !     wf     - sinking velocity at flux interfaces [m/d], dimension (nl, 6)
+    !     zf     - depth at flux interfaces [m, negative], dimension (nl)
+    !     thick  - layer thickness [m], dimension (nl-1)
+    !     recipthick - 1/thick [1/m], dimension (nl-1)
+    !
+    !   Cavity convention (nzmin > 1):
+    !     - wF, thick, recipthick, and zf are only filled for the active range
+    !       [nzmin, nzmax]; values outside are left at zero.
+    !     - Surface boundary wF(nzmin, :) = 0 replaces wF(1, :) = 0.
+    !     - Bottom boundary wF(nzmax+1, :) = 0.
     !===============================================================================
-    subroutine Depth_calculations(n, nn, wf, zf, thick, recipthick, nl, hnode, zbar_3d_n)
+    subroutine Depth_calculations(n, nzmin, nn, wf, zf, thick, recipthick, nl, hnode, zbar_3d_n)
 
         use recom_config, only: ivcoc, ivdia, ivdet, ivdetsc, ivpha, ivphy, VCalc, VDet, &
                 VDet_zoo2, VCocco, VPhaeo, VDia, VPhy
@@ -24,51 +41,49 @@ contains
         implicit none
 
         ! Input parameters
-        integer, intent(in) :: n ! Current node
-        integer, intent(in) :: nn ! Total number of vertical nodes
+        integer, intent(in) :: n       ! Node index
+        integer, intent(in) :: nzmin   ! Top active level (1 = open ocean, >1 = cavity)
+        integer, intent(in) :: nn      ! Bottom active level (= nlevels_nod2D(n) - 1)
         integer, intent(in) :: nl
         real(kind=WP), intent(in), dimension(:, :) :: hnode, zbar_3d_n
 
         ! Output arrays
-        ! [m/day] Flux velocities at the border of the control volumes
+        ! Sinking velocities at flux interfaces [m/d]; index 1 = ivphy..ivpha
         real(kind=wp), dimension(nl, 6), intent(out) :: wf
 
-        ! [m] Depth of vertical fluxes
+        ! Depths at flux interfaces [m, negative]
         real(kind=wp), dimension(nl), intent(out) :: zf
 
-        ! [m] Distance between two nodes = layer thickness
+        ! Layer thicknesses [m] and their reciprocals [1/m]
         real(kind=wp), dimension(nl - 1), intent(out) :: thick
-
-        ! [1/m] Reciprocal thickness
         real(kind=wp), dimension(nl - 1), intent(out) :: recipthick
 
         ! Local variables
-        integer :: k ! Layer index
+        integer :: k
 
-        ! ======================================================================================
-        !! zbar(nl) allocate the array for storing the standard depths (depth of layers)
-        !! zbar is negative
-        !! Z(nl-1)  mid-depths of layers
+        !---------------------------------------------------------------------------
+        ! Initialise all output arrays to zero so unused levels stay clean
+        !---------------------------------------------------------------------------
+        wf         = 0.0d0
+        zf         = 0.0d0
+        thick      = 0.0_WP
+        recipthick = 0.0_WP
 
-        ! zbar_n: depth of layers due to ale thinkness variations at every node n
-        !    allocate(zbar_n(nl))
-        !    allocate(zbar_3d_n(nl,myDim_nod2D+eDim_nod2D))
-
-        ! Z_n: mid depth of layers due to ale thinkness variations at every node n
-        !    allocate(Z_n(nl-1))
-        !    allocate(Z_3d_n(nl-1,myDim_nod2D+eDim_nod2D))
-        ! ============================================================================== modular
-
-        !! Background sinking speed
-        wF(2:Nn, ivphy) = VPhy ! Phytoplankton sinking velocity
-        wF(2:Nn, ivdia) = VDia ! Diatoms sinking velocity
-        wF(2:Nn, ivdet) = VDet ! Detritus sinking velocity
-        wF(2:Nn, ivdetsc) = VDet_zoo2 ! Second detritus sinking velocity
-        wF(2:Nn, ivcoc) = VCocco ! Coccolithophores sinking velocity
-        wF(2:Nn, ivpha) = VPhaeo ! Phaeocystis sinking velocity
+        !---------------------------------------------------------------------------
+        ! Background sinking velocities at interior flux interfaces
+        !   Range nzmin+1:nzmax covers interfaces between active layers.
+        !   The top (nzmin) and bottom (nzmax+1) interfaces remain zero -
+        !   no flux enters from above the top active level or exits below the bottom.
+        !---------------------------------------------------------------------------
+        wf(nzmin+1:Nn, ivphy)   = VPhy      ! Small phytoplankton
+        wf(nzmin+1:Nn, ivdia)   = VDia      ! Diatoms
+        wf(nzmin+1:Nn, ivdet)   = VDet      ! Detritus class 1
+        wf(nzmin+1:Nn, ivdetsc) = VDet_zoo2 ! Detritus class 2
+        wf(nzmin+1:Nn, ivcoc)   = VCocco    ! Coccolithophores
+        wf(nzmin+1:Nn, ivpha)   = VPhaeo    ! Phaeocystis
 
         !! Boundary conditions (surface and bottom)
-        wF(1, :) = 0.d0
+        wF(nzmin, :) = 0.d0
         wF(Nn + 1, :) = 0.d0
 
         !if (allow_var_sinking) then
@@ -77,23 +92,22 @@ contains
         !    wF(2:Nn+1,ivdet) = Vcalc * abs(zbar_3d_n(2:Nn+1, n)) + VDet
         !end if
 
-        !! Calculate layer thickness and reciprocal of it
-        thick = 0.0_WP
-        recipthick = 0.0_WP
-        zf = 0.0_WP
-
-        do k = 1, nn
+        !---------------------------------------------------------------------------
+        ! Layer thickness and its reciprocal over the active column
+        !---------------------------------------------------------------------------
+        do k = nzmin, nn
             thick(k) = hnode(k, n)
             if (hnode(k, n) > 0.0_WP) then
-                !        if thick(k) > 0.0_WP) then        ! alternative
                 recipthick(k) = 1.0 / hnode(k, n)
             else
                 recipthick(k) = 0.0_WP
             end if
         end do
 
-        !! set layer depth (negative)
-        do k = 1, nn + 1
+        !---------------------------------------------------------------------------
+        ! Flux-interface depths over the active column (including bottom face)
+        !---------------------------------------------------------------------------
+        do k = nzmin, nn + 1
             zf(k) = zbar_3d_n(k, n)
         end do
 
@@ -150,7 +164,19 @@ contains
     end function solar_incidence_cosine
 
     !===============================================================================
-    ! Subroutine for calculating cos(AngleOfIncidence)
+    ! Cobeta
+    !   Computes cosAI(n): cosine of the angle of incidence of sunlight at the
+    !   sea surface after refraction at the air-water interface, for each node.
+    !
+    !   Uses the solar declination formula of Paltridge & Platt (1976) and
+    !   Snell's law with refractive index nWater = 1.33.
+    !
+    !   This routine is geometry-only and is cavity-safe <E2><80><94> it does not access
+    !   vertical levels.
+    !
+    !   Reference:
+    !     Paltridge & Platt (1976), Radiative Processes in Meteorology and
+    !     Climatology, Elsevier, ISBN 0-444-41444-4.
     !===============================================================================
     subroutine Cobeta(daynew, ndpyr, myDim_nod2D, geo_coord_nod2D)
 

--- a/recom_forcing.F90
+++ b/recom_forcing.F90
@@ -8,8 +8,12 @@ contains
 
     !===============================================================================
     ! REcoM_Forcing
+    !
+    !   Cavity convention (nzmin > 1):
+    !     CO2 and O2 surface fluxes are set to zero; all other BGC progresses
+    !     normally through the water column below the ice shelf.
     !===============================================================================
-    subroutine REcoM_Forcing(n, Nn, state, SurfSW, Loc_slp, Temp, Sali, Sali_depth, &
+    subroutine REcoM_Forcing(n, nzmin, Nn, state, SurfSW, Loc_slp, Temp, Sali, Sali_depth, &
             CO2_watercolumn, pH_watercolumn, pCO2_watercolumn, &
             HCO3_watercolumn, CO3_watercolumn, OmegaC_watercolumn, &
             kspc_watercolumn, rhoSW_watercolumn, PAR, MPI_COMM_FESOM, &
@@ -26,7 +30,7 @@ contains
                 vertgrazmacro_tot, vertgrazmacro_n, vertgrazmacro_d, vertgrazmacro_c, &
                 vertgrazmacro_mes, vertgrazmacro_det, vertgrazmacro_mic, vertgrazmacro_det2, &
                 vertgrazmicro_tot, vertgrazmicro_n, vertgrazmicro_d, vertgrazmicro_c, &
-                locgrazmacro_c, locgrazmacro_c, locgrazmacro_d, locgrazmacro_det, &
+                locgrazmacro_c, locgrazmacro_d, locgrazmacro_det, &
                 locgrazmacro_mes, locgrazmacro_mic, locgrazmacro_n, locgrazmacro_p, &
                 locgrazmeso_c, locgrazmeso_d, locgrazmeso_det, locgrazmeso_det2, locgrazmeso_mic, &
                 locgrazmeso_n, locgrazmeso_p, locgrazmeso_tot, locgrazmicro_c, locgrazmicro_d, &
@@ -49,7 +53,7 @@ contains
 
         use recom_locvar, only: betad, co2, co2ex, dpco2surf, fco2, hco3, k0, kw660, loc_ice_conc, &
                 locatmco2, o2ex, o2flux_seaicemask, oflux, omegaa, omegac, p, pco2surf, ph, rhosw, &
-                tempis, uloc, co2flux, co2flux, co3, co2flux_seaicemask, dflux
+                tempis, uloc, co2flux, co3, co2flux_seaicemask, dflux
 
         use recom_extra, only: cobeta, depth_calculations
         use recom_sms_module, only: recom_sms
@@ -58,19 +62,21 @@ contains
         implicit none
 
         integer, intent(in) :: daynew, ndpyr, mype, myDim_nod2D, eDim_nod2D, nl, mstep
-        integer, intent(in) :: MPI_COMM_FESOM, n, Nn ! Nn -Total number of nodes
+
+        ! Node index, top active level, bottom active level
+        integer, intent(in) :: n, nzmin, Nn
+        integer, intent(in) :: MPI_COMM_FESOM
 
         real(kind=wp), intent(in) :: rad
         real(kind=wp), intent(in) :: Sali ! Salinity of current surface layer
-        real(kind=wp), intent(in) :: SurfSW ! [W/m2] ShortWave radiation at surface
-        real(kind=wp), intent(in) :: Loc_slp ! [Pa] sea-level pressure
+        real(kind=wp), intent(in) :: SurfSW ! Shortwave at surface [W/m2]
+        real(kind=wp), intent(in) :: Loc_slp ! Sea-level pressure [Pa]
         real(kind=wp), intent(inout) :: kappa, dt
 
-        real(kind=wp), intent(in), dimension(nl - 1) :: Temp ! [degrees C] Ocean temperature
-        ! Salinity for the whole water column
-        real(kind=wp), intent(in), dimension(nl - 1) :: Sali_depth
+        real(kind=wp), intent(in), dimension(nl - 1) :: Temp ! Potential temperature [deg C]
+        real(kind=wp), intent(in), dimension(nl - 1) :: Sali_depth ! Salinity profile
 
-        !!---- Watercolumn carbonate chemistry
+        ! Carbonate chemistry profiles (mocsy + DISS), updated in place
         real(kind=wp), intent(inout), dimension(nl - 1) :: CO2_watercolumn
         real(kind=wp), intent(inout), dimension(nl - 1) :: pH_watercolumn
         real(kind=wp), intent(inout), dimension(nl - 1) :: pCO2_watercolumn
@@ -79,84 +85,95 @@ contains
         real(kind=wp), intent(inout), dimension(nl - 1) :: OmegaC_watercolumn
         real(kind=wp), intent(inout), dimension(nl - 1) :: kspc_watercolumn
         real(kind=wp), intent(inout), dimension(nl - 1) :: rhoSW_watercolumn
+
+        ! PAR profile [W/m2], computed here and returned to caller
         real(kind=wp), intent(inout), dimension(nl - 1) :: PAR
 
         real(kind=WP), intent(in), dimension(:, :) :: hnode, zbar_3d_n
         real(kind=WP), intent(in), dimension(:, :) :: geo_coord_nod2D
         real(kind=wp), intent(inout), dimension(nl - 1, bgc_num) :: state
 
-        real(kind=wp) :: Latr
+        !---------------------------------------------------------------------------
+        ! Mocsy / CO2-flux inputs (size-1 arrays - mocsy uses array interfaces)
+        !   Note: Sali shadows the dummy argument Sali_depth for the surface
+        !   value only, avoiding a name collision with the profile array.
+        !---------------------------------------------------------------------------
+        real(kind=wp) :: REcoM_DIC(1)  ! DIC at surface [mol/m3]
+        real(kind=wp) :: REcoM_Alk(1)  ! Alkalinity at surface [mol/m3]
+        real(kind=wp) :: REcoM_Si(1)   ! Silicate at surface [mol/m3]
+        real(kind=wp) :: REcoM_Phos(1) ! Phosphate at surface [mol/m3] (from DIN/Redfield)
+        real(kind=wp) :: Latd(1)       ! latitude [degrees]
+        real(kind=wp) :: Lond(1)       ! longitude [degrees]
+        real(kind=wp) :: REcoM_T(1)    ! Surface temperature, clamped for Lueker K1/K2 [deg C]
+        real(kind=wp) :: REcoM_S(1)    ! clamped for Lueker K1/K2
+        real(kind=wp) :: Patm(1)       ! Atmospheric pressure [atm]
+        real(kind=wp) :: Latr          ! Latitude [radians], scalar scratch
 
-        !!---- Subroutine CO2Flux /mocsy
-        ! [mol/m3] Conc of DIC in the surface water, used to calculate CO2 flux
-        real(kind=wp) :: REcoM_DIC(1)
-        ! [mol/m3] Conc of Alk in the surface water, used to calculate CO2 flux
-        real(kind=wp) :: REcoM_Alk(1)
-        ! [mol/m3] Conc of Si in the surface water, used to calculate CO2 flux
-        real(kind=wp) :: REcoM_Si(1)
-        ! [mol/m3] Conc of Phos in the surface water, used to calculate the CO2 flux
-        real(kind=wp) :: REcoM_Phos(1)
-        real(kind=wp) :: Latd(1) ! latitude in degree
-        real(kind=wp) :: Lond(1) ! longitude in degree
-        real(kind=wp) :: REcoM_T(1) ! temperature again, for mocsy minimum defined as -2
-        real(kind=wp) :: REcoM_S(1) ! temperature again, for mocsy minimum defined as 21
+        !---------------------------------------------------------------------------
+        ! O2-flux inputs
+        !---------------------------------------------------------------------------
+        real(kind=wp) :: ppo(1)        ! Sea-level pressure normalised to 1 atm [-]
+        real(kind=wp) :: REcoM_O2(1)   ! Surface O2 [mol/m3]
 
-        ! atm pressure, now read in as forcing!!
-        !!---- atm pressure
-        real(kind=wp) :: Patm(1) ! atmospheric pressure [atm]
-
-        !!---- Subroutine o2flux /mocsy
-        real(kind=wp) :: ppo(1) ! atmospheric pressure, divided by 1 atm
-        ! [mmol/m3] Conc of O2 in the surface water, used to calculate O2 flux
-        real(kind=wp) :: REcoM_O2(1)
-
-        !!---- Subroutine Depth
-
-        real(kind=wp), dimension(nl) :: zF ! [m] Depth of fluxes
-        real(kind=wp), dimension(nl, 6) :: SinkVel ! [m/day]
-        ! [m] Vertical distance between two nodes = Thickness
-        real(kind=wp), dimension(nl - 1) :: thick
-        real(kind=wp), dimension(nl - 1) :: recipthick ! [1/m] reciprocal of thick
-
-        !!---- Subroutine REcoM_sms
-        ! matrix that entail changes in tracer concentrations
+        !---------------------------------------------------------------------------
+        ! SMS tendency [mmol/m3/timestep]
+        !---------------------------------------------------------------------------
         real(kind=wp), dimension(nl - 1, bgc_num) :: sms
 
-        ! 0.00001/ 3.15d0   Chl2N_max [mg CHL/mmol N] Maximum CHL a : N ratio = 0.3 gCHL gN^-1
-        tiny_N = tiny_chl / chl2N_max
-        tiny_N_d = tiny_chl / chl2N_max_d ! 0.00001/ 4.2d0
+        !---------------------------------------------------------------------------
+        ! Local geometry
+        !---------------------------------------------------------------------------
+        real(kind=wp), dimension(nl)     :: zF         ! Depth at flux points [m]
+        real(kind=wp), dimension(nl, 6)  :: SinkVel    ! Sinking velocities [m/d]
+        real(kind=wp), dimension(nl - 1) :: thick      ! Layer thickness [m]
+        real(kind=wp), dimension(nl - 1) :: recipthick ! 1/thick [1/m]
 
-        ! NCmax   = 0.2d0   [mmol N/mmol C] Maximum cell quota of nitrogen (N:C)
-        tiny_C = tiny_N / NCmax
-        tiny_C_d = tiny_N_d / NCmax_d ! NCmax_d = 0.2d0
-
-        tiny_Si = tiny_C_d / SiCmax ! SiCmax = 0.8d0
+        !---------------------------------------------------------------------------
+        ! Threshold concentrations derived from config parameters
+        !   tiny_X = minimum meaningful concentration for species X, used as lower
+        !   bound after the SMS update and as a near-zero guard in ratio calculations.
+        !---------------------------------------------------------------------------
+        tiny_N   = tiny_chl / chl2N_max    ! [mmol N/m3]  small phytoplankton N
+        tiny_N_d = tiny_chl / chl2N_max_d  ! [mmol N/m3]  diatom N
+        tiny_C   = tiny_N   / NCmax        ! [mmol C/m3]  small phytoplankton C
+        tiny_C_d = tiny_N_d / NCmax_d      ! [mmol C/m3]  diatom C
+        tiny_Si  = tiny_C_d / SiCmax       ! [mmol Si/m3] diatom Si
 
         if (enable_coccos) then
-            tiny_N_c = tiny_chl / chl2N_max_c ! 0.00001/ 3.5d0
-            tiny_C_c = tiny_N_c / NCmax_c ! NCmax_c = 0.15d0
-
-            tiny_N_p = tiny_chl / chl2N_max_p ! 0.00001/ 3.5d0
-            tiny_C_p = tiny_N_p / NCmax_p ! NCmax_c = 0.15d0
+            tiny_N_c = tiny_chl / chl2N_max_c  ! [mmol N/m3]  coccolithophore N
+            tiny_C_c = tiny_N_c / NCmax_c      ! [mmol C/m3]  coccolithophore C
+            tiny_N_p = tiny_chl / chl2N_max_p  ! [mmol N/m3]  phaeocystis N
+            tiny_C_p = tiny_N_p / NCmax_p      ! [mmol C/m3]  phaeocystis C
         end if
 
+        !---------------------------------------------------------------------------
+        ! Grid geometry for this column
+        !---------------------------------------------------------------------------
         call Cobeta(daynew, ndpyr, myDim_nod2D, geo_coord_nod2D)
-        call Depth_calculations(n, Nn, SinkVel, zF, thick, recipthick, nl, hnode, zbar_3d_n)
+        call Depth_calculations(n, nzmin, Nn, SinkVel, zF, thick, recipthick, nl, hnode, zbar_3d_n)
 
-        !! *** Mocsy ***
+        !===========================================================================
+        ! Surface gas exchange
+        !   Cavity nodes (nzmin > 1): fluxes are forced to zero - there is no
+        !   atmosphere - ocean interface below an ice shelf.
+        !===========================================================================
 
-        !!---- convert from mmol/m3 to mol/m3
-        REcoM_DIC = max(tiny * 1e-3, state(one, idic) * 1e-3)
-        REcoM_Alk = max(tiny * 1e-3, state(one, ialk) * 1e-3)
-        REcoM_Si = max(tiny * 1e-3, state(one, isi) * 1e-3)
-
-        !!---- convert N to P with Redfield ratio
-        REcoM_Phos = max(tiny * 1e-3, state(one, idin) * 1e-3) / 16.
+        !---------------------------------------------------------------------------
+        ! Prepare surface-layer scalars for mocsy
+        !   Lueker (2000) K1/K2 valid range: T in [2, 35] deg C, S in [19, 43].
+        !   We clamp to [2, 40] deg C and [21, 43] to avoid extrapolation errors,
+        !   including in near-freezing, low-salinity, high-ice-cover cells.
+        !---------------------------------------------------------------------------
+        REcoM_DIC  = max(tiny * 1e-3, state(one, idic) * 1e-3) ! mmol/m3 -> mol/m3
+        REcoM_Alk  = max(tiny * 1e-3, state(one, ialk) * 1e-3)
+        REcoM_Si   = max(tiny * 1e-3, state(one, isi)  * 1e-3)
+        REcoM_Phos = max(tiny * 1e-3, state(one, idin) * 1e-3) / 16.d0  ! N->P Redfield
+        REcoM_O2   = max(tiny * 1e-3, state(one, ioxy) * 1e-3)
 
         !!---- minimum set to 2 degC: K1/K2 Lueker valid between 2degC-35degC and 19-43psu
-        REcoM_T = max(2.d0, Temp(1))
+        REcoM_T = max(2.d0, Temp(nzmin))
         !!---- maximum set to 40 degC: K1/K2 Lueker valid between 2degC-35degC and 19-43psu
-        REcoM_T = min(REcoM_T, 40.d0)
+        REcoM_T = min(40.d0, REcoM_T(1))
 
         !!---- minimum set to 21: K1/K2 Lueker valid between 2degC-35degC and 19-43psu, else causes
         !!trouble in regions with S between 19 and 21 and ice conc above 97%
@@ -164,14 +181,13 @@ contains
         !!---- maximum set to 43: K1/K2 Lueker valid between 2degC-35degC and 19-43psu, else causes
         !!trouble   REcoM_S    = min(REcoM_S, 43.d0)  !!!!!!!!
 
-        !!---- convert from Pa to atm.
-        Patm = Loc_slp / Pa2atm
+        Patm = Loc_slp / Pa2atm ! Pa -> atm
 
         !!---- lon
-        Lond = geo_coord_nod2D(1, n) / rad !! convert from rad to degree
+        Lond = geo_coord_nod2D(1, n) / rad ! rad -> degrees
         !!---- lat
-        Latr = geo_coord_nod2D(2, n)
-        Latd = geo_coord_nod2D(2, n) / rad !! convert from rad to degree
+        Latr = geo_coord_nod2D(2, n)       ! radians (scratch)
+        Latd = geo_coord_nod2D(2, n) / rad ! rad -> degrees
 
         !!---- calculate piston velocity kw660, which is an input to the flxco2 calculation
         !!---- pistonvel already scaled for ice-free area
@@ -183,92 +199,106 @@ contains
         !! kw660: piston velocity at 25°C [m/s], uncorrected by the Schmidt number for different
         !! temperatures
 
+        !---------------------------------------------------------------------------
+        ! Piston velocity kw660 at 25 deg C [m/s]
+        !   Computed unconditionally; set to zero inside REcoM_sms for cavities.
+        !   Ice-cover fraction is already folded in by pistonvel - do not reapply.
+        !---------------------------------------------------------------------------
+
         call pistonvel(ULoc, Loc_ice_conc, Nmocsy, kw660)
 
-        !! *** check ***
-
-        if ((REcoM_DIC(1) > 10000.d0)) then ! NEW: added this entire print statement (if to endif)
-            print*, 'NEW ERROR: DIC !'
-            print*, 'pco2surf: ', pco2surf
-            print*, 'co2: ', co2
-            print*, 'rhoSW: ', rhoSW
-            print*, 'temp: ', REcoM_T
-            print*, 'tempis: ', tempis
-            print*, 'REcoM_S: ', REcoM_S
-            print*, 'REcoM_Alk: ', REcom_Alk
-            print*, 'REcoM_DIC: ', REcoM_DIC
-            print*, 'REcoM_Si: ', REcoM_Si
-            print*, 'REcoM_Phos: ', REcoM_Phos
-            print*, 'kw660: ', kw660
-            print*, 'LocAtmCO2: ', LocAtmCO2
-            print*, 'Patm: ', Patm
-            print*, 'thick(One): ', thick(One)
-            print*, 'Nmocsy: ', Nmocsy
-            print*, 'Lond: ', Lond
-            print*, 'Latd: ', Latd
-            print*, 'ULoc: ', ULoc
-            print*, 'Loc_ice_conc: ', Loc_ice_conc
+        ! Guard against unphysical DIC (indicates upstream tracer corruption)
+        if (REcoM_DIC(1) > 10.d0) then  ! > 10 mol/m3 = 10000 mmol/m3
+            print *, 'FATAL: DIC out of range at n=', n
+            print *, '  DIC   [mol/m3] =', REcoM_DIC
+            print *, '  Alk   [mol/m3] =', REcoM_Alk
+            print *, '  T     [deg C]  =', REcoM_T
+            print *, '  S              =', REcoM_S
+            print *, '  Si    [mol/m3] =', REcoM_Si
+            print *, '  Phos  [mol/m3] =', REcoM_Phos
+            print *, '  pCO2           =', pco2surf
+            print *, '  rhoSW          =', rhoSW
+            print *, '  tempis         =', tempis
+            print *, '  kw660          =', kw660
+            print *, '  AtmCO2         =', LocAtmCO2
+            print *, '  Patm   [atm]   =', Patm
+            print *, '  ULoc   [m/s]   =', ULoc
+            print *, '  ice_conc       =', Loc_ice_conc
+            print *, '  thick(nzmin)   =', thick(nzmin)
+            print *, '  Nmocsy         =', Nmocsy
+            print *, '  Lond, Latd     =', Lond, Latd
             stop
         end if
 
-        call flxco2(co2flux, co2ex, dpco2surf, ph, pco2surf, fco2, co2, hco3, co3, OmegaA, OmegaC, &
-                BetaD, rhoSW, p, tempis, K0, REcoM_T, REcoM_S, REcoM_Alk, REcoM_DIC, REcoM_Si, &
-                REcoM_Phos, kw660, LocAtmCO2, Patm, thick(One), Nmocsy, Lond, Latd, &
-                optCON='mol/m3', optT='Tpot   ', optP='m ', optB='u74', optK1K2='l  ', optKf='dg', &
-                optGAS='Pinsitu', optS='Sprc')
+        if (nzmin == 1) then
+            call flxco2(co2flux, co2ex, dpco2surf, ph, pco2surf, fco2, co2, hco3, co3, OmegaA, OmegaC, &
+                    BetaD, rhoSW, p, tempis, K0, REcoM_T, REcoM_S, REcoM_Alk, REcoM_DIC, REcoM_Si, &
+                    REcoM_Phos, kw660, LocAtmCO2, Patm, thick(One), Nmocsy, Lond, Latd, &
+                    optCON='mol/m3', optT='Tpot   ', optP='m ', optB='u74', optK1K2='l  ', optKf='dg', &
+                    optGAS='Pinsitu', optS='Sprc')
 
-        ! changed optK1K2='l  ' to 'm10'
-        if ((co2flux(1) > 1.e10) .or. (co2flux(1) < -1.e10)) then
-            !     co2flux(1)=0.0
-            print*, 'ERROR: co2 flux !'
-            print*, 'pco2surf: ', pco2surf
-            print*, 'co2: ', co2
-            print*, 'rhoSW: ', rhoSW
-            print*, 'temp: ', REcoM_T
-            print*, 'tempis: ', tempis
-            print*, 'REcoM_S: ', REcoM_S
-            print*, 'REcoM_Alk: ', REcom_Alk
-            print*, 'REcoM_DIC: ', REcoM_DIC
-            print*, 'REcoM_Si: ', REcoM_Si
-            print*, 'REcoM_Phos: ', REcoM_Phos
-            print*, 'kw660: ', kw660
-            print*, 'LocAtmCO2: ', LocAtmCO2
-            print*, 'Patm: ', Patm
-            print*, 'thick(One): ', thick(One)
-            print*, 'Nmocsy: ', Nmocsy
-            print*, 'Lond: ', Lond
-            print*, 'Latd: ', Latd
-            print*, 'ULoc: ', ULoc
-            print*, 'Loc_ice_conc: ', Loc_ice_conc
-            stop
+            ! Sanity check on computed flux magnitude
+
+            if (abs(co2flux(1)) > 1.e10) then
+                print *, 'FATAL: CO2 flux out of range at n=', n
+                print *, '  co2flux        =', co2flux
+                print *, '  pco2surf       =', pco2surf
+                print *, '  co2            =', co2
+                print *, '  rhoSW          =', rhoSW
+                print *, '  T     [deg C]  =', REcoM_T
+                print *, '  tempis         =', tempis
+                print *, '  S              =', REcoM_S
+                print *, '  Alk   [mol/m3] =', REcoM_Alk
+                print *, '  DIC   [mol/m3] =', REcoM_DIC
+                print *, '  Si    [mol/m3] =', REcoM_Si
+                print *, '  Phos  [mol/m3] =', REcoM_Phos
+                print *, '  kw660          =', kw660
+                print *, '  AtmCO2         =', LocAtmCO2
+                print *, '  Patm   [atm]   =', Patm
+                print *, '  thick(nzmin)   =', thick(nzmin)
+                print *, '  Nmocsy         =', Nmocsy
+                print *, '  Lond, Latd     =', Lond, Latd
+                print *, '  ULoc   [m/s]   =', ULoc
+                print *, '  ice_conc       =', Loc_ice_conc
+                stop
+            end if
+
+            ! Ice fraction already in piston velocity - do not re-apply here
+            dflux              = co2flux * 1.e3 * SecondsPerDay  ! mol/m2/s -> mmol/m2/d
+            co2flux_seaicemask = co2flux * 1.e3                  ! mol/m2/s -> mmol/m2/s
+        else  ! cavity - no atmosphere above
+            dflux              = 0.0_WP
+            co2flux_seaicemask = 0.0_WP
+            pco2surf = 0.0_WP
+            dpco2surf = 0.0_WP
+            ph = 0.0_WP
+            kw660 = 0.0_WP
+            K0 = 0.0_WP
+            omegaC = 0.0_WP
+            omegaA = 0.0_WP
+        end if
+ 
+        !---------------------------------------------------------------------------
+        ! O2 air-sea flux (open ocean only)
+        !---------------------------------------------------------------------------
+        ppo = Loc_slp / Pa2atm  ! sea-level pressure normalised to 1 atm
+
+        if (nzmin == 1) then
+            call o2flux(REcoM_T, REcoM_S, kw660, ppo, REcoM_O2, Nmocsy, o2ex)
+            oflux              = o2ex * 1.e3 * SecondsPerDay  ! mol/m2/s -> mmol/m2/d
+            o2flux_seaicemask  = o2ex * 1.e3                  ! mol/m2/s -> mmol/m2/s
+        else
+            oflux              = 0.0_WP
+            o2flux_seaicemask  = 0.0_WP
         end if
 
-        ! use ice-free area and also convert from mol/m2/s to mmol/m2/d
-        !   if(mype==0) write(*,*), 'co2flux (mol/m2/s) =',co2flux
-
-        ! ice-fraction is already considered in piston-velocity, so don't apply it here
-        dflux = co2flux * 1.e3 * SecondsPerDay !* (1.d0 - Loc_ice_conc)
-        !   if(mype==0) write(*,*), 'dflux (mmol/m2/d) =',dflux
-
-        co2flux_seaicemask = co2flux * 1.e3 !  [mmol/m2/s]  * (1.d0 - Loc_ice_conc)
-        !   if(mype==0) write(*,*), 'co2flux_seaicemask (mmol/m2/s) =',co2flux_seaicemask
-
-        ! then oxygen
-        ppo = Loc_slp / Pa2atm !1 !slp divided by 1 atm
-
-        ! convert from mmol/m3 to mol/m3 for mocsy
-        REcoM_O2 = max(tiny * 1e-3, state(one, ioxy) * 1e-3)
-
-        call o2flux(REcoM_T, REcoM_S, kw660, ppo, REcoM_O2, Nmocsy, o2ex)
-        oflux = o2ex * 1.e3 * SecondsPerDay !* (1.d0 - Loc_ice_conc) [mmol/m2/d]
-        o2flux_seaicemask = o2ex * 1.e3 ! back to mmol here [mmol/m2/s]
-
-        ! Source-Minus-Sinks
-
+        !===========================================================================
+        ! Water-column BGC <E2><80><94> sources minus sinks
+        !===========================================================================
         if (recom_debug .and. mype == 0) print *, achar(27) // '[36m' // '     --> REcoM_sms' // &
                 achar(27) // '[0m'
 
-        call REcoM_sms(n, Nn, state, thick, SurfSW, sms, Temp, Sali_depth, &
+        call REcoM_sms(n, nzmin, Nn, state, thick, SurfSW, sms, Temp, Sali_depth, &
                 CO2_watercolumn, & ! MOCSY [mol/m3]
                 pH_watercolumn, & ! MOCSY on total scale
                 pCO2_watercolumn, & ! MOCSY [uatm]
@@ -280,37 +310,42 @@ contains
                 Loc_slp, zF, PAR, Latd, daynew, dt, kappa, mstep, MPI_COMM_FESOM, mype, &
                 myDim_nod2D, eDim_nod2D, nl, geo_coord_nod2D)
 
-        state(1:nn, :) = max(tiny, state(1:nn, :) + sms(1:nn, :))
+        !---------------------------------------------------------------------------
+        ! Apply SMS tendency and enforce lower concentration bounds
+        !---------------------------------------------------------------------------
+        state(nzmin:nn, :) = max(tiny, state(nzmin:nn, :) + sms(nzmin:nn, :))
 
-        state(1:nn, ipchl) = max(tiny_chl, state(1:nn, ipchl))
-        state(1:nn, iphyn) = max(tiny_N, state(1:nn, iphyn))
-        state(1:nn, iphyc) = max(tiny_C, state(1:nn, iphyc))
-        state(1:nn, idchl) = max(tiny_chl, state(1:nn, idchl))
-        state(1:nn, idian) = max(tiny_N_d, state(1:nn, idian))
-        state(1:nn, idiac) = max(tiny_C_d, state(1:nn, idiac))
-        state(1:nn, idiasi) = max(tiny_Si, state(1:nn, idiasi))
+        ! Per-species lower bounds (tighter than the generic 'tiny')
+        state(nzmin:nn, ipchl)  = max(tiny_chl, state(nzmin:nn, ipchl))
+        state(nzmin:nn, iphyn)  = max(tiny_N,   state(nzmin:nn, iphyn))
+        state(nzmin:nn, iphyc)  = max(tiny_C,   state(nzmin:nn, iphyc))
+        state(nzmin:nn, idchl)  = max(tiny_chl, state(nzmin:nn, idchl))
+        state(nzmin:nn, idian)  = max(tiny_N_d, state(nzmin:nn, idian))
+        state(nzmin:nn, idiac)  = max(tiny_C_d, state(nzmin:nn, idiac))
+        state(nzmin:nn, idiasi) = max(tiny_Si,  state(nzmin:nn, idiasi))
 
         if (enable_coccos) then
-            state(1:nn, icchl) = max(tiny_chl, state(1:nn, icchl))
-            state(1:nn, icocn) = max(tiny_N_c, state(1:nn, icocn))
-            state(1:nn, icocc) = max(tiny_C_c, state(1:nn, icocc))
+            state(nzmin:nn, icchl) = max(tiny_chl, state(nzmin:nn, icchl))
+            state(nzmin:nn, icocn) = max(tiny_N_c, state(nzmin:nn, icocn))
+            state(nzmin:nn, icocc) = max(tiny_C_c, state(nzmin:nn, icocc))
 
-            state(1:nn, iphachl) = max(tiny_chl, state(1:nn, iphachl))
-            state(1:nn, iphan) = max(tiny_N_p, state(1:nn, iphan))
-            state(1:nn, iphac) = max(tiny_C_p, state(1:nn, iphac))
+            state(nzmin:nn, iphachl) = max(tiny_chl, state(nzmin:nn, iphachl))
+            state(nzmin:nn, iphan)   = max(tiny_N_p, state(nzmin:nn, iphan))
+            state(nzmin:nn, iphac)   = max(tiny_C_p, state(nzmin:nn, iphac))
         end if
 
         if (enable_3zoo2det) then
-            state(1:nn, imiczoon) = max(tiny, state(1:nn, imiczoon))
-            state(1:nn, imiczooc) = max(tiny, state(1:nn, imiczooc))
+            state(nzmin:nn, imiczoon) = max(tiny, state(nzmin:nn, imiczoon))
+            state(nzmin:nn, imiczooc) = max(tiny, state(nzmin:nn, imiczooc))
         end if
 
-        state(1:nn, idicremin) = max(tiny, state(1:nn, idicremin))
+        state(nzmin:nn, idicremin) = max(tiny, state(nzmin:nn, idicremin))
 
         if (recom_debug .and. mype == 0) print *, achar(27) // '[36m' // '     --> ciso after' // &
                 ' REcoM_Forcing' // achar(27) // '[0m'
 
         if (ciso) then
+            if (nzmin == 1) then
             ! Calculate carbon-isotopic fractionation, radioactive decay is calculated in
             ! oce_ale_tracer.F90
 
@@ -343,8 +378,8 @@ contains
             call recom_ciso_photo(co2(1)) ! -> alpha_p
             r_phyc_13 = r_co2s_13 / alpha_p_13
             r_diac_13 = r_co2s_13 / alpha_p_dia_13
-            state(1:nn, iphyc_13) = max((tiny_C * r_phyc_13), (state(1:nn, iphyc) * r_phyc_13))
-            state(1:nn, idiac_13) = max((tiny_C_d * r_diac_13), (state(1:nn, idiac) * r_diac_13))
+            state(nzmin:nn, iphyc_13) = max((tiny_C * r_phyc_13), (state(nzmin:nn, iphyc) * r_phyc_13))
+            state(nzmin:nn, idiac_13) = max((tiny_C_d * r_diac_13), (state(nzmin:nn, idiac) * r_diac_13))
 
             ! The same for radiocarbon, fractionation factors have been already derived above
             if (ciso_14) then
@@ -362,12 +397,20 @@ contains
                 if (ciso_organic_14) then
                     r_phyc_14 = r_co2s_14 / alpha_p_14
                     r_diac_14 = r_co2s_14 / alpha_p_dia_14
-                    state(1:nn, iphyc_14) = max((tiny_C * r_phyc_14), (state(1:nn, iphyc) &
+                    state(nzmin:nn, iphyc_14) = max((tiny_C * r_phyc_14), (state(nzmin:nn, iphyc) &
                             * r_phyc_14))
-                    state(1:nn, idiac_14) = max((tiny_C_d * r_diac_14), (state(1:nn, idiac) &
+                    state(nzmin:nn, idiac_14) = max((tiny_C_d * r_diac_14), (state(nzmin:nn, idiac) &
                             * r_diac_14))
                 end if
             end if
+            else
+                co2flux_13 = 0.0_WP
+                co2flux_seaicemask_13 = 0.0_WP
+                if (ciso_14) then
+                    co2flux_14 = 0.0_WP
+                    co2flux_seaicemask_14 = 0.0_WP
+                endif
+            endif 
             ! Radiocarbon
         end if
         ! ciso
@@ -379,68 +422,68 @@ contains
             ! logical, optional                 :: lNPPn
 
             ! if (present(lNPPn))then
-            !     locNPPn = sum(diags3Dloc(1:nn,idiags) * thick(1:nn))
+            !     locNPPn = sum(diags3Dloc(nzmin:nn,idiags) * thick(nzmin:nn))
             ! endif
-            locNPPn = sum(vertNPPn(1:nn) * thick(1:nn))
-            locGPPn = sum(vertGPPn(1:nn) * thick(1:nn))
-            locNNAn = sum(vertNNAn(1:nn) * thick(1:nn))
-            locChldegn = sum(vertChldegn(1:nn) * thick(1:nn))
+            locNPPn = sum(vertNPPn(nzmin:nn) * thick(nzmin:nn))
+            locGPPn = sum(vertGPPn(nzmin:nn) * thick(nzmin:nn))
+            locNNAn = sum(vertNNAn(nzmin:nn) * thick(nzmin:nn))
+            locChldegn = sum(vertChldegn(nzmin:nn) * thick(nzmin:nn))
 
-            locNPPd = sum(vertNPPd(1:nn) * thick(1:nn))
-            locGPPd = sum(vertGPPd(1:nn) * thick(1:nn))
-            locNNAd = sum(vertNNAd(1:nn) * thick(1:nn))
-            locChldegd = sum(vertChldegd(1:nn) * thick(1:nn))
+            locNPPd = sum(vertNPPd(nzmin:nn) * thick(nzmin:nn))
+            locGPPd = sum(vertGPPd(nzmin:nn) * thick(nzmin:nn))
+            locNNAd = sum(vertNNAd(nzmin:nn) * thick(nzmin:nn))
+            locChldegd = sum(vertChldegd(nzmin:nn) * thick(nzmin:nn))
 
             if (enable_coccos) then
-                locNPPc = sum(vertNPPc(1:nn) * thick(1:nn))
-                locGPPc = sum(vertGPPc(1:nn) * thick(1:nn))
-                locNNAc = sum(vertNNAc(1:nn) * thick(1:nn))
-                locChldegc = sum(vertChldegc(1:nn) * thick(1:nn))
+                locNPPc = sum(vertNPPc(nzmin:nn) * thick(nzmin:nn))
+                locGPPc = sum(vertGPPc(nzmin:nn) * thick(nzmin:nn))
+                locNNAc = sum(vertNNAc(nzmin:nn) * thick(nzmin:nn))
+                locChldegc = sum(vertChldegc(nzmin:nn) * thick(nzmin:nn))
 
-                locNPPp = sum(vertNPPp(1:nn) * thick(1:nn))
-                locGPPp = sum(vertGPPp(1:nn) * thick(1:nn))
-                locNNAp = sum(vertNNAp(1:nn) * thick(1:nn))
-                locChldegp = sum(vertChldegp(1:nn) * thick(1:nn))
+                locNPPp = sum(vertNPPp(nzmin:nn) * thick(nzmin:nn))
+                locGPPp = sum(vertGPPp(nzmin:nn) * thick(nzmin:nn))
+                locNNAp = sum(vertNNAp(nzmin:nn) * thick(nzmin:nn))
+                locChldegp = sum(vertChldegp(nzmin:nn) * thick(nzmin:nn))
             end if
 
             ! only for the case if grazing detritus is used, as probably only
             ! needed for tuning which uses detritus grazing
             if (Grazing_detritus) then
                 ! Mesozooplankton
-                locgrazmeso_tot = sum(vertgrazmeso_tot(1:nn) * thick(1:nn))
-                locgrazmeso_n = sum(vertgrazmeso_n(1:nn) * thick(1:nn))
-                locgrazmeso_d = sum(vertgrazmeso_d(1:nn) * thick(1:nn))
+                locgrazmeso_tot = sum(vertgrazmeso_tot(nzmin:nn) * thick(nzmin:nn))
+                locgrazmeso_n = sum(vertgrazmeso_n(nzmin:nn) * thick(nzmin:nn))
+                locgrazmeso_d = sum(vertgrazmeso_d(nzmin:nn) * thick(nzmin:nn))
                 if (enable_coccos) then
-                    locgrazmeso_c = sum(vertgrazmeso_c(1:nn) * thick(1:nn))
-                    locgrazmeso_p = sum(vertgrazmeso_p(1:nn) * thick(1:nn))
+                    locgrazmeso_c = sum(vertgrazmeso_c(nzmin:nn) * thick(nzmin:nn))
+                    locgrazmeso_p = sum(vertgrazmeso_p(nzmin:nn) * thick(nzmin:nn))
                 end if
-                locgrazmeso_det = sum(vertgrazmeso_det(1:nn) * thick(1:nn))
+                locgrazmeso_det = sum(vertgrazmeso_det(nzmin:nn) * thick(nzmin:nn))
                 if (enable_3zoo2det) then
-                    locgrazmeso_mic = sum(vertgrazmeso_mic(1:nn) * thick(1:nn))
-                    locgrazmeso_det2 = sum(vertgrazmeso_det2(1:nn) * thick(1:nn))
+                    locgrazmeso_mic = sum(vertgrazmeso_mic(nzmin:nn) * thick(nzmin:nn))
+                    locgrazmeso_det2 = sum(vertgrazmeso_det2(nzmin:nn) * thick(nzmin:nn))
                 end if
 
                 if (enable_3zoo2det) then
                     ! Macrozooplankton
-                    locgrazmacro_tot = sum(vertgrazmacro_tot(1:nn) * thick(1:nn))
-                    locgrazmacro_n = sum(vertgrazmacro_n(1:nn) * thick(1:nn))
-                    locgrazmacro_d = sum(vertgrazmacro_d(1:nn) * thick(1:nn))
+                    locgrazmacro_tot = sum(vertgrazmacro_tot(nzmin:nn) * thick(nzmin:nn))
+                    locgrazmacro_n = sum(vertgrazmacro_n(nzmin:nn) * thick(nzmin:nn))
+                    locgrazmacro_d = sum(vertgrazmacro_d(nzmin:nn) * thick(nzmin:nn))
                     if (enable_coccos) then
-                        locgrazmacro_c = sum(vertgrazmacro_c(1:nn) * thick(1:nn))
-                        locgrazmacro_p = sum(vertgrazmacro_p(1:nn) * thick(1:nn))
+                        locgrazmacro_c = sum(vertgrazmacro_c(nzmin:nn) * thick(nzmin:nn))
+                        locgrazmacro_p = sum(vertgrazmacro_p(nzmin:nn) * thick(nzmin:nn))
                     end if
-                    locgrazmacro_mes = sum(vertgrazmacro_mes(1:nn) * thick(1:nn))
-                    locgrazmacro_det = sum(vertgrazmacro_det(1:nn) * thick(1:nn))
-                    locgrazmacro_mic = sum(vertgrazmacro_mic(1:nn) * thick(1:nn))
-                    locgrazmacro_det2 = sum(vertgrazmacro_det2(1:nn) * thick(1:nn))
+                    locgrazmacro_mes = sum(vertgrazmacro_mes(nzmin:nn) * thick(nzmin:nn))
+                    locgrazmacro_det = sum(vertgrazmacro_det(nzmin:nn) * thick(nzmin:nn))
+                    locgrazmacro_mic = sum(vertgrazmacro_mic(nzmin:nn) * thick(nzmin:nn))
+                    locgrazmacro_det2 = sum(vertgrazmacro_det2(nzmin:nn) * thick(nzmin:nn))
 
                     ! Microzooplankton
-                    locgrazmicro_tot = sum(vertgrazmicro_tot(1:nn) * thick(1:nn))
-                    locgrazmicro_n = sum(vertgrazmicro_n(1:nn) * thick(1:nn))
-                    locgrazmicro_d = sum(vertgrazmicro_d(1:nn) * thick(1:nn))
+                    locgrazmicro_tot = sum(vertgrazmicro_tot(nzmin:nn) * thick(nzmin:nn))
+                    locgrazmicro_n = sum(vertgrazmicro_n(nzmin:nn) * thick(nzmin:nn))
+                    locgrazmicro_d = sum(vertgrazmicro_d(nzmin:nn) * thick(nzmin:nn))
                     if (enable_coccos) then
-                        locgrazmicro_c = sum(vertgrazmicro_c(1:nn) * thick(1:nn))
-                        locgrazmicro_p = sum(vertgrazmicro_p(1:nn) * thick(1:nn))
+                        locgrazmicro_c = sum(vertgrazmicro_c(nzmin:nn) * thick(nzmin:nn))
+                        locgrazmicro_p = sum(vertgrazmicro_p(nzmin:nn) * thick(nzmin:nn))
                     end if
 
                 end if

--- a/recom_main.F90
+++ b/recom_main.F90
@@ -58,12 +58,15 @@ contains
         !     end do
         !  end if
 
-        !___________________________________________________________________________
-        ! Balance alkalinity restoring to climatology
+        !---------------------------------------------------------------------------
+        ! Compute local relaxation flux at the open-ocean surface layer.
+        ! Cavity nodes (ulevels_nod2D > 1) are skipped - no surface exchange.
+        !---------------------------------------------------------------------------
+
         do n = 1, myDim_nod2D + eDim_nod2D
-            !        relax_alk(n)=surf_relax_Alk * (Alk_surf(n) - tracers%data(2+ialk)%values(1, n))
-            !        relax_alk(n)=surf_relax_Alk * (Alk_surf(n) - alkalinity(ulevels_nod2d(n),n)
-            relax_alk(n) = surf_relax_Alk * (Alk_surf(n) - alkalinity(1, n))
+            if (ulevels_nod2d(n) == 1) then
+                relax_alk(n) = surf_relax_Alk * (Alk_surf(n) - alkalinity(1, n))
+            end if
         end do
 
         ! 2. virtual alkalinity flux
@@ -72,11 +75,13 @@ contains
         !     virtual_alk=virtual_alk-net/ocean_area
         !  end if
 
-        ! 3. restoring to Alkalinity climatology
+        !---------------------------------------------------------------------------
+        ! Remove global mean to conserve total ocean alkalinity
+        !---------------------------------------------------------------------------
         call integrate_nod_2D_recom(relax_alk, net, MPI_COMM_FESOM, myDim_nod2D, &
                 ulevels_nod2D, areasvol)
 
-        relax_alk = relax_alk - net / ocean_area ! at ocean surface layer
+        relax_alk = relax_alk - net / ocean_area
 
     end subroutine bio_fluxes
 end module bio_fluxes_interface
@@ -189,23 +194,33 @@ contains
         !! u_wind and v_wind are always at nodes
         ! ======================================================================================
 
-        real(kind=wp) :: SW, Loc_slp
+        ! Loop indices and node-level counters
         integer :: tr_num, tracer_id
-        integer :: n, nzmax
+        integer :: n, nzmin, nzmax
 
-        real(kind=wp) :: Sali
+        ! Scalar local state
+        real(kind=wp) :: SW           ! Photosynthetically active shortwave [W/m2]
+        real(kind=wp) :: Loc_slp      ! Local sea-level pressure [atm]
+        real(kind=wp) :: Sali         ! Surface salinity
+
+
+        ! Flag for annual-event output of isotopic CO2 (has SAVE semantics via initializer)
         logical :: do_update
 
-        real(kind=wp), allocatable :: Temp(:), Sali_depth(:), zr(:), PAR(:)
-        real(kind=wp), allocatable :: C(:, :)
+        ! Vertical profile temporaries (size nl-1, allocated per node-count nl)
+        real(kind=8), allocatable :: Temp(:)          ! Potential temperature [deg C]
+        real(kind=8), allocatable :: Sali_depth(:)    ! Salinity profile
+        real(kind=8), allocatable :: zr(:)            ! Mid-layer depths [m, negative]
+        real(kind=8), allocatable :: PAR(:)           ! PAR profile [W/m2]
+        real(kind=8), allocatable :: C(:,:)           ! BGC tracer concentrations
 
-        !! * Mocsy *
+        ! Carbonate chemistry - mocsy output
         real(kind=wp), allocatable :: CO2_watercolumn(:)
         real(kind=wp), allocatable :: pH_watercolumn(:)
         real(kind=wp), allocatable :: pCO2_watercolumn(:)
         real(kind=wp), allocatable :: HCO3_watercolumn(:)
 
-        !! * Diss *
+        ! Carbonate chemistry - DISS output
         real(kind=wp), allocatable :: CO3_watercolumn(:)
         real(kind=wp), allocatable :: OmegaC_watercolumn(:)
         real(kind=wp), allocatable :: kspc_watercolumn(:)
@@ -217,7 +232,9 @@ contains
         integer                    :: n_transit_tracers   ! number of active transit tracers
         integer                    :: bgc_start, bgc_end  ! first/last slot of the BGC-only block
  
-
+        !---------------------------------------------------------------------------
+        ! Allocate per-column work arrays (full depth nl-1)
+        !---------------------------------------------------------------------------
         allocate(Temp(nl - 1), Sali_depth(nl - 1), zr(nl - 1), PAR(nl - 1))
         allocate(C(nl - 1, bgc_num))
         allocate(CO2_watercolumn(nl - 1), pH_watercolumn(nl - 1), pCO2_watercolumn(nl - 1), &
@@ -245,11 +262,9 @@ contains
 
         do_update = .false.
 
-        ! ice concentration [0 to 1]
-
-        ! alkalinity restoring to climatology
-        ! virtual flux is possible
-
+        !---------------------------------------------------------------------------
+        ! Optional alkalinity restoring to climatology (surface virtual flux)
+        !---------------------------------------------------------------------------
         if (restore_alkalinity) then
             !call bio_fluxes(tracers_info%data_pointers(2 + ialk)%tracer_data(:, :), &
             call bio_fluxes(tracers_info%data_pointers(bgc_start - 1 + ialk)%tracer_data(:, :), &
@@ -260,17 +275,20 @@ contains
             print *, achar(27) // '[36m' // '     --> bio_fluxes' // achar(27) // '[0m'
         end if
 
-        if (use_atbox) then ! MERGE
-            ! Prognostic atmospheric isoCO2
+        !---------------------------------------------------------------------------
+        ! Prognostic atmospheric CO2 box (use_atbox)
+        !---------------------------------------------------------------------------
+        if (use_atbox) then
             call recom_atbox(MPI_COMM_FESOM, myDim_nod2D, ulevels_nod2D, areasvol, dt)
-            ! optional I/O of isoCO2 and inferred cosmogenic 14C production; this may cost some
-            ! CPU time
+            ! Optional isotope / cosmogenic-14C annual output
             if (ciso .and. ciso_14) then
                 if ((daynew == ndpyr) .and. abs(timenew - 86400.) < tiny) then
                     do_update = .true.
                 else
                     do_update = .false.
                 end if
+                ! OG: Alternative
+                !call annual_event(do_update)
 
                 if (do_update .and. mype == 0) write(*, fmt = '(a50,2x,i6,4(2x,f6.2))') &
                         'Year, xCO2 (ppm), cosmic 14C flux (at / cm² / s):', &
@@ -279,11 +297,15 @@ contains
             end if
         end if
 
-        ! Resetting DICremin tracer to zero when reaching surface (added by Sina) 
+        ! Resetting DICremin tracer to zero when reaching surface (added by Sina)   !!!!! Check
         do tr_num = 1,num_tracers
             tracer_id = tracers_info%ids(tr_num)
             if (tracer_id == tracer_ids%dic_remineralization) then
-                tracers_info%data_pointers(tr_num)%tracer_data(1, :)  = 0.0_WP
+                do n = 1, myDim_nod2D
+                    ! Under a cavity, level 1 is inactive/masked, so the "true" surface DICremin never gets reset 
+                    ! and can accumulate indefinitely if we ise (1,:) We need an explicit solution. Loop over n.
+                    tracers_info%data_pointers(tr_num)%tracer_data(ulevels_nod2D(n), n) = 0.0_WP
+                end do
             end if
         end do
 
@@ -291,13 +313,13 @@ contains
         !********************************* LOOP STARTS *****************************************
 
         do n = 1, myDim_nod2D ! needs exchange_nod in the end
-            !     if (ulevels_nod2D(n)>1) cycle
-            !       nzmin = ulevels_nod2D(n)
 
-            !!---- Number of vertical layers
-            nzmax = nlevels_nod2D(n) - 1
+            nzmin = ulevels_nod2D(n)     ! top active level (>1 means ice-shelf cavity)
+            nzmax = nlevels_nod2D(n) - 1 ! bottom active level
 
-            !!---- This is needed for piston velocity
+            !-----------------------------------------------------------------------
+            ! Sea-ice concentration and sea-level pressure
+            !-----------------------------------------------------------------------
             Loc_ice_conc = ice_data_values(n)
 
             !!---- Mean sea level pressure
@@ -309,14 +331,21 @@ contains
             Loc_slp = press_air(n)
 #endif
 
-            !!---- Benthic layers
+            !-----------------------------------------------------------------------
+            ! Benthic layer state for this column
+            !-----------------------------------------------------------------------
             LocBenthos(1:benthos_num) = Benthos(n, 1:benthos_num)
 
-            !!---- Local conc of [H+]-ions from last time step. Decleared and saved in LocVar.
-            !!---- used as first guess for H+ conc. in subroutine CO2flux (provided by recom_init)
+            !-----------------------------------------------------------------------
+            ! H+ first guess from previous time step (used in CO2flux Newton solver)
+            !-----------------------------------------------------------------------
             Hplus = GloHplus(n)
 
-            !!---- Interpolated wind from atmospheric forcing
+            !-----------------------------------------------------------------------
+            ! 10-m wind speed
+            !   Cavity nodes: wind is excluded from surface forcing inside
+            !   REcoM_Forcing, but ULoc is still set here for code simplicity.
+            !-----------------------------------------------------------------------
 #if defined(__oasis)
             !! Derive 10m-wind speed from wind stress fields, see module recom_ciso.
             !! This is an ad-hoc solution as long as 10m-winds are not handled from OASIS.
@@ -353,38 +382,49 @@ contains
                 if (ciso_14) r_atm_14 = LocAtmCO2_14(1) / LocAtmCO2(1)
             end if
 
-            !!---- Shortwave penetration
-            SW = parFrac * shortwave(n)
-            SW = SW * (1.d0 - ice_data_values(n))
+            !-----------------------------------------------------------------------
+            ! Shortwave (PAR fraction), scaled by open-water fraction
+            !   Cavity nodes: no light penetration from above.
+            !-----------------------------------------------------------------------
+            if (nzmin > 1) then
+                SW = 0.d0            ! ice-shelf cavity - no shortwave
+            else
+                SW = parFrac * shortwave(n)
+                SW = SW * (1.d0 - ice_data_values(n))
+            end if
 
             !!---- Temperature in water column
-            Temp(1:nzmax) = tracers_info%data_pointers(1)%tracer_data(1:nzmax, n)
+            Temp(nzmin:nzmax) = tracers_info%data_pointers(1)%tracer_data(nzmin:nzmax, n)
 
             !!---- Surface salinity
             Sali = tracers_info%data_pointers(2)%tracer_data(1, n)
-            Sali_depth(1:nzmax) = tracers_info%data_pointers(2)%tracer_data(1:nzmax, n)
+            Sali_depth(nzmin:nzmax) = tracers_info%data_pointers(2)%tracer_data(nzmin:nzmax, n)
 
-            !!---- CO2 in the watercolumn
+            !-----------------------------------------------------------------------
+            ! Carbonate chemistry profiles (mocsy + DISS) from previous time step
+            !-----------------------------------------------------------------------
+            CO2_watercolumn(nzmin:nzmax)    = CO23D(nzmin:nzmax, n)
+            pH_watercolumn(nzmin:nzmax)     = pH3D(nzmin:nzmax, n)
+            pCO2_watercolumn(nzmin:nzmax)   = pCO23D(nzmin:nzmax, n)
+            HCO3_watercolumn(nzmin:nzmax)   = HCO33D(nzmin:nzmax, n)
+            CO3_watercolumn(nzmin:nzmax)    = CO33D(nzmin:nzmax, n)
+            OmegaC_watercolumn(nzmin:nzmax) = OmegaC3D(nzmin:nzmax, n)
+            kspc_watercolumn(nzmin:nzmax)   = kspc3D(nzmin:nzmax, n)
+            rhoSW_watercolumn(nzmin:nzmax)  = rhoSW3D(nzmin:nzmax, n)
 
-            !! * Mocsy *
-            CO2_watercolumn(1:nzmax) = CO23D(1:nzmax, n)
-            pH_watercolumn(1:nzmax) = pH3D(1:nzmax, n)
-            pCO2_watercolumn(1:nzmax) = pCO23D(1:nzmax, n)
-            HCO3_watercolumn(1:nzmax) = HCO33D(1:nzmax, n)
-            !! * Diss *
-            CO3_watercolumn(1:nzmax) = CO33D(1:nzmax, n)
-            OmegaC_watercolumn(1:nzmax) = OmegaC3D(1:nzmax, n)
-            kspc_watercolumn(1:nzmax) = kspc3D(1:nzmax, n)
-            rhoSW_watercolumn(1:nzmax) = rhoSW3D(1:nzmax, n)
-
-            !!---- Biogeochemical tracers
+            !-----------------------------------------------------------------------
+            ! BGC tracer concentrations (offset by 2 for T and S at front)
+            !-----------------------------------------------------------------------
             do tr_num = bgc_start, bgc_end
-                C(1:nzmax, tr_num-num_physical_tracers) = tracers_info%data_pointers(tr_num)%tracer_data(1:nzmax, n)
+                C(nzmin:nzmax, tr_num-num_physical_tracers) = tracers_info%data_pointers(tr_num)%tracer_data(nzmin:nzmax, n)
             end do
 
+            !-----------------------------------------------------------------------
+            ! Backup tracer state for SMS (sources minus sinks) diagnostics
+            !-----------------------------------------------------------------------
             ttf_rhs_bak = 0.0
 
-            do tr_num = 1, num_tracers
+            do tr_num = 1, num_tracers   !!!!! Check OG
                 if (tracers_info%ltra_diag(tr_num)) then
                     ttf_rhs_bak(1:nzmax, tr_num) = &
                             tracers_info%data_pointers(tr_num)%tracer_data(1:nzmax, n)
@@ -394,12 +434,22 @@ contains
             !!---- Depth of the nodes in the water column
             zr(1:nzmax) = Z_3d_n(1:nzmax, n)
 
-            !!---- The PAR in the local water column is initialized
+            !-----------------------------------------------------------------------
+            ! Mid-layer depths and PAR initialisation
+            !-----------------------------------------------------------------------
             PAR(1:nzmax) = 0.d0
-
-            !!---- ice_data_values(row): Ice concentration in the local node
-            FeDust = GloFeDust(n) * (1.d0 - ice_data_values(n)) * dust_sol
-            NDust = GloNDust(n) * (1.d0 - ice_data_values(n))
+        
+            !-----------------------------------------------------------------------
+            ! Atmospheric dust / nitrogen deposition
+            !   Cavity nodes: no atmospheric input reaching the ocean surface.
+            !-----------------------------------------------------------------------
+            if (nzmin > 1) then
+                FeDust = 0.0_WP
+                NDust  = 0.0_WP
+            else
+                FeDust = GloFeDust(n) * (1.d0 - ice_data_values(n)) * dust_sol
+                NDust  = GloNDust(n)  * (1.d0 - ice_data_values(n))
+            end if
 
             if (Diags) then
                 ! Allocate and initialize all diagnostic arrays for a water column
@@ -413,7 +463,10 @@ contains
 
             ! ======================================================================================
             !******************************** RECOM FORCING ****************************************
-            call REcoM_Forcing(n, nzmax, C, SW, Loc_slp, Temp, Sali, Sali_depth, &
+            !-----------------------------------------------------------------------
+            ! BGC time step <E2><80><94> updates C, PAR, carbonate chemistry, and surface fluxes
+            !-----------------------------------------------------------------------
+            call REcoM_Forcing(n, nzmin, nzmax, C, SW, Loc_slp, Temp, Sali, Sali_depth, &
                     CO2_watercolumn, & ! NEW MOCSY CO2 for the whole watercolumn
                     pH_watercolumn, & ! NEW MOCSY pH for the whole watercolumn
                     pCO2_watercolumn, & ! NEW MOCSY pCO2 for the whole watercolumn
@@ -427,11 +480,12 @@ contains
                     geo_coord_nod2D, daynew, ndpyr, dt, kappa, mstep, rad)
 
             do tr_num = bgc_start, bgc_end
-                tracers_info%data_pointers(tr_num)%tracer_data(1:nzmax, n) = C(1:nzmax, tr_num-num_physical_tracers)
+                tracers_info%data_pointers(tr_num)%tracer_data(nzmin:nzmax, n) = C(nzmin:nzmax, tr_num-num_physical_tracers)
             end do
 
-            ! recom_sms
-
+            !-----------------------------------------------------------------------
+            ! Sources-minus-sinks (SMS) tendency for diagnostic tracers
+            !-----------------------------------------------------------------------
             do tr_num = 1, num_tracers
                 if (tracers_info%ltra_diag(tr_num)) then
                     tra_recom_sms(1:nzmax, n, tr_num) = &
@@ -442,16 +496,21 @@ contains
 
             end do
 
-            !!---- Local variables that have been changed during the time-step are stored so they
-            !!can be saved
+            !-----------------------------------------------------------------------
+            ! Store updated benthic state and decay rates
+            !-----------------------------------------------------------------------
             Benthos(n, 1:benthos_num) = LocBenthos(1:benthos_num)
+            ! Convert decay rate from [mmol/m2/d] to [mmol/m2/s]
+            GlodecayBenthos(n, 1:benthos_num) = &
+                decayBenthos(1:benthos_num) / SecondsPerDay
 
-            ! convert from [mmol/m2/d] to [mmol/m2/s]
-            GlodecayBenthos(n, 1:benthos_num) = decayBenthos(1:benthos_num) / SecondsPerDay
 
             if (recom_debug .and. mype == 0) print *, achar(27) // '[36m' // '     --> ciso' // &
                     ' after REcoM_Forcing' // achar(27) // '[0m'
 
+            !-----------------------------------------------------------------------
+            ! Accumulate 2D/3D diagnostics and deallocate column arrays
+            !-----------------------------------------------------------------------
             if (Diags) then
                 call update_2d_diags(n)
                 call update_3d_diags(n, nzmax)
@@ -481,16 +540,16 @@ contains
             PAR3D(1:nzmax, n) = PAR(1:nzmax)
 
             !! * Mocsy *
-            CO23D(1:nzmax, n) = CO2_watercolumn(1:nzmax)
-            pH3D(1:nzmax, n) = pH_watercolumn(1:nzmax)
-            pCO23D(1:nzmax, n) = pCO2_watercolumn(1:nzmax)
-            HCO33D(1:nzmax, n) = HCO3_watercolumn(1:nzmax)
+            CO23D(nzmin:nzmax, n) = CO2_watercolumn(nzmin:nzmax)
+            pH3D(nzmin:nzmax, n) = pH_watercolumn(nzmin:nzmax)
+            pCO23D(nzmin:nzmax, n) = pCO2_watercolumn(nzmin:nzmax)
+            HCO33D(nzmin:nzmax, n) = HCO3_watercolumn(nzmin:nzmax)
 
             !! * Diss *
-            CO33D(1:nzmax, n) = CO3_watercolumn(1:nzmax)
-            OmegaC3D(1:nzmax, n) = OmegaC_watercolumn(1:nzmax)
-            kspc3D(1:nzmax, n) = kspc_watercolumn(1:nzmax)
-            rhoSW3D(1:nzmax, n) = rhoSW_watercolumn(1:nzmax)
+            CO33D(nzmin:nzmax, n) = CO3_watercolumn(nzmin:nzmax)
+            OmegaC3D(nzmin:nzmax, n) = OmegaC_watercolumn(nzmin:nzmax)
+            kspc3D(nzmin:nzmax, n) = kspc_watercolumn(nzmin:nzmax)
+            rhoSW3D(nzmin:nzmax, n) = rhoSW_watercolumn(nzmin:nzmax)
         end do
 
         ! ======================================================================================

--- a/recom_modules.F90
+++ b/recom_modules.F90
@@ -1205,7 +1205,6 @@ contains
         logical :: id_error
         integer :: slot                   ! running slot index when building expected_ids
 
-        logical :: num_physical_tracers
         integer, parameter :: n_base_physical = 2   ! T (id=1), S (id=2)
 
         ! ---- count active transit tracers -----------------------------------------
@@ -1220,7 +1219,7 @@ contains
 
         ! ---- actual BGC count: strip non-BGC appended tracers --------------------
         ! tracer_init now appends in this order:  T,S | BGC | [age] | [transit]
-        ! num_physical_tracers here is just T,S (=2) in the reordered layout.
+        ! n_base_physical here is just T,S (=2) in the reordered layout.
         actual_bgc_num = num_tracers - n_base_physical
         if (use_age_tracer) actual_bgc_num = actual_bgc_num - 1
         actual_bgc_num = actual_bgc_num - n_transit_tracers
@@ -1280,8 +1279,6 @@ contains
         expected_total_tracers = n_base_physical + expected_bgc_num
         if (use_age_tracer) expected_total_tracers = expected_total_tracers + 1
         expected_total_tracers = expected_total_tracers + n_transit_tracers
-
-        num_physical_tracers = n_base_physical
 
         ! ===========================================================================
         ! Build expected tracer ID list for current configuration
@@ -1669,7 +1666,6 @@ contains
         integer :: slot                    ! running slot for age + transit tail
         integer :: n_transit_tracers       ! number of active transit tracers
         integer, parameter :: n_base_physical = 2   ! T (id=1), S (id=2)
-        logical :: num_physical_tracers
 
         error_found = .false.
         duplicate_found = .false.
@@ -1688,9 +1684,6 @@ contains
             ! Additional DICremin: 1 tracer (1037) (added by Sina)
             bgc_num_local = 23
         end if
-
-        ! num_physical_tracers (global) is just T,S in the new layout
-        num_physical_tracers = n_base_physical
 
         ! Allocate expected IDs array
         allocate(expected_ids(num_tracers))

--- a/recom_sinking.F90
+++ b/recom_sinking.F90
@@ -12,10 +12,26 @@ public :: get_seawater_viscosity
 contains
 
     !===============================================================================
-    ! YY: sinking of second detritus adapted from Ozgur's code
-    ! but not using recom_det_tracer_id, since
-    ! second detritus has a different sinking speed than the first
-    ! define recom_det2_tracer_id to make it consistent???
+    ! ver_sinking_recom_benthos
+    !   Computes vertical sinking of particulate tracers into the benthos layer.
+    !
+    !   For each locally-owned open-ocean node the sinking velocity is selected
+    !   by tracer ID, the downward flux through each layer interface is accumulated
+    !   into str_bf, and the net material reaching the seafloor is added to the
+    !   appropriate Benthos bucket (N, C, Si, Cal) and optionally to the MEDUSA
+    !   sediment flux arrays.
+    !
+    !   Cavity nodes (ulevels_nod2D > 1) are skipped - there is no overlying
+    !   water column above the ice-shelf cavity base that could deposit material
+    !   onto a benthic boundary.
+    !
+    !   Note: second-detritus class (zoo2det) uses a separate sinking speed
+    !   (VDet_zoo2) and is identified by hardcoded IDs (1025-1028) because no
+    !   recom_det2_tracer_id array is defined yet.
+    !   TODO: define recom_det2_tracer_id in recom_declarations for consistency
+    !         with recom_det_tracer_id / recom_phy_tracer_id / recom_dia_tracer_id.
+    !   TODO: replace all hardcoded tracer IDs with named constants from
+    !         recom_declarations throughout this file.
     !===============================================================================
     subroutine ver_sinking_recom_benthos(tr_num, nl, ulevels_nod2D, nlevels_nod2D, zbar_3d_n, &
             nod_in_elem2D_num, nod_in_elem2D, nlevels, area, tracer_id, tracer_data_values, &
@@ -59,6 +75,9 @@ contains
         real(kind=WP) :: tv
 
         do n = 1, myDim_nod2D ! needs exchange_nod in the end
+
+            if (ulevels_nod2D(n) > 1) cycle ! Cavity guard
+
             nl1 = nlevels_nod2D(n) - 1
             ul1 = ulevels_nod2D(n)
 
@@ -333,7 +352,7 @@ contains
 
             select case (tracer_id)
             case (1001)
-                bottom_flux = GloSed(:, 1) * area(1, :) ! DIN
+                bottom_flux = GloSed(:, 1) * area(1, :) ! DIN     !FIXME: (areasvol(ul1,:) OG: 02.06.2026
             case (1002)
                 bottom_flux = GloSed(:, 2) * area(1, :) ! DIC
             case (1003)
@@ -413,10 +432,13 @@ contains
             !_______________________________________________________________________
             ! Bottom flux
             do nz = nlevels_nod2D_minimum, nl1
-                vd_flux(nz) = (area(nz, n) - area(nz + 1, n)) * bottom_flux(n) / (area(1, n))
+                !vd_flux(nz) = (area(nz, n) - area(nz + 1, n)) * bottom_flux(n) / (area(1, n))
+                vd_flux(nz)=(area(nz,n)-area(nz+1,n))* bottom_flux(n)/(areasvol(ul1,n))
             end do
             nz = nl1
-            vd_flux(nz + 1) = (area(nz + 1, n)) * bottom_flux(n) / (area(1, n))
+            !vd_flux(nz + 1) = (area(nz + 1, n)) * bottom_flux(n) / (area(1, n))
+            vd_flux(nz+1)= (area(nz+1,n))* bottom_flux(n)/(areasvol(ul1,n))
+
             !_______________________________________________________________________
             ! writing flux into rhs
             do nz = ul1, nl1
@@ -584,10 +606,10 @@ contains
 
                     !! ---- We assume constant sinking for second detritus
                     if (enable_3zoo2det .and. &
-                        tracer_id == tracer_ids%macrozooplankton_detrital_nitrogen .or. & !idetz2n
+                        (tracer_id == tracer_ids%macrozooplankton_detrital_nitrogen .or. & !idetz2n
                         tracer_id == tracer_ids%macrozooplankton_detrital_carbon .or. & !idetz2c
                         tracer_id == tracer_ids%macrozooplankton_detrital_silica .or. & !idetz2si
-                        tracer_id == tracer_ids%macrozooplankton_detrital_calcite) then !idetz2calc
+                        tracer_id == tracer_ids%macrozooplankton_detrital_calcite)) then !idetz2calc
                         Wvel_flux(nz) = -VDet_zoo2 / SecondsPerDay
 
                         if (use_ballasting) then
@@ -622,10 +644,7 @@ contains
                 dt_sink = dt
                 vd_flux = 0.0d0
 
-                !FIXME: Having IF True and IF False is bad practice. Either throw away the old code,
-                !or make a namelist switch...
                 ! 3rd Order DST Sceheme with flux limiting. This code comes from old recom
-                if (.true.) then
 
                     k = nod_in_elem2D_num(n)
                     ! Screening minimum depth in neigbouring nodes around node n
@@ -664,9 +683,8 @@ contains
                                 0.5 * wM * (tracer_data_values(max(nzmin, nz - 1), n) + psiP * Rj))
                         vd_flux(nz) = -tv * area(nz, n)
                     end do
-                end if ! 3rd Order DST Sceheme with flux limiting
 
-                if (.false.) then ! simple upwind
+                if (.false.) then ! simple upwind FIXME: use a flag here later
 
                     ! Surface flux
                     vd_flux(nzmin) = 0.0_WP
@@ -703,9 +721,23 @@ contains
 
     end subroutine ver_sinking_recom
 
-    !-------------------------------------------------------------------------------
-    ! Subroutine calculate ballasting
-    !-------------------------------------------------------------------------------
+!===============================================================================
+! ballast
+!   Computes per-node, per-level scaling factors for the ballasted sinking
+!   velocity parameterisation (Cram et al. 2018).
+!
+!   Scaling factors:
+!     scaling_density1/2_3D - ratio of (particle - seawater) excess density
+!                              to a reference excess density; set to 1.0 if
+!                              density scaling is disabled or particle is less
+!                              dense than seawater.
+!     scaling_visc_3D       - ratio of reference viscosity to local seawater
+!                              viscosity; set to 1.0 if viscosity scaling is
+!                              disabled or viscosity is zero.
+!
+!   The actual sinking velocities are assembled in ver_sinking_recom using
+!   w_ref1/2 * scaling_density * scaling_visc (+ optional depth term).
+!===============================================================================
     subroutine ballast(myDim_nod2D, ulevels_nod2D, nlevels_nod2D, geo_coord_nod2D, Z_3d_n, &
             tracer_data_values_1, tracer_data_values_2, rad)
 
@@ -727,107 +759,94 @@ contains
         real(kind=WP), intent(in), dimension(:, :) :: geo_coord_nod2D, Z_3d_n
         real(kind=WP), intent(in), dimension(:, :) :: tracer_data_values_1, tracer_data_values_2
 
-        integer :: row, k, nzmin, nzmax
-        real(kind=wp) :: depth_pos(1)
-        real(kind=wp) :: pres(1)
-        real(kind=wp) :: sa(1)
-        real(kind=wp) :: ct(1)
-        real(kind=wp) :: rho_seawater(1)
+        integer       :: row, k, nzmin, nzmax
+        real(kind=wp) :: depth_pos(1)    ! Layer mid-depth [m, positive]
+        real(kind=wp) :: pres(1)         ! Layer mid-depth [m, positive]
+        real(kind=wp) :: sa(1)           ! Absolute salinity [g/kg]
+        real(kind=wp) :: ct(1)           ! Conservative temperature [deg C]
+        real(kind=wp) :: rho_seawater(1) ! In-situ seawater density [kg/m3]
         real(kind=wp) :: Lon_degree(1)
         real(kind=wp) :: Lat_degree(1)
 
-        ! For ballasting, calculate scaling factors here and pass them to FESOM, where sinking
-        ! velocities are calculated
-        ! -----
-        ! If ballasting is used, sinking velocities are a function of a) particle composition
-        ! (=density),
-        ! b) sea water viscosity, c) depth (currently for small detritus only), and d) a constant
-        ! reference sinking speed
-        ! -----
-
-        ! check oce_ale_tracer.F90
-        !     call get_seawater_viscosity(mesh) ! seawater_visc_3D
-        !     call get_particle_density(mesh) ! rho_particle = density of particle class 1 and 2
-        !___________________________________________________________________________
-        ! loop over local nodes
+        ! For ballasting, calculate scaling factors here and pass them to FESOM,
+        ! where sinking velocities are computed from these factors plus a reference speed.
+        !
+        ! Sinking velocity depends on:
+        !   a) particle composition (= density)
+        !   b) sea-water viscosity
+        !   c) depth (currently small detritus only)
+        !   d) a constant reference sinking speed
         do row = 1, myDim_nod2D
-            ! max. number of levels at node n
+
             nzmin = ulevels_nod2D(row)
+            ! nlevels_nod2D counts layer interfaces; subtract 1 to get the number
+            ! of layer centres (= the last valid tracer/velocity level index).
+
             nzmax = nlevels_nod2D(row)
-            !! lon
-            Lon_degree(1) = geo_coord_nod2D(1, row) / rad !! convert from rad to degree
-            !! lat
-            Lat_degree(1) = geo_coord_nod2D(2, row) / rad !! convert from rad to degree
 
-            ! get scaling vectors -> these need to be passed to FESOM to get sinking velocities
-            ! get local seawater density
+            Lon_degree(1) = geo_coord_nod2D(1, row) / rad
+            Lat_degree(1) = geo_coord_nod2D(2, row) / rad
+
             do k = nzmin, nzmax
-
-                !! level depth
-                ! take depth of tracers instead of levels abs(zbar_3d_n(k,row))
+                ! --- seawater density at this node/level ---
                 depth_pos(1) = abs(Z_3d_n(k, row))
-
-                ! pres is output of function,1=number of records
+                ! FIX OG: Pass length-1 arrays (not scalar elements) to depth2press so
+                !      the interface matches its expected array dummy arguments.
                 call depth2press(depth_pos(1), Lat_degree(1), pres, 1)
-                sa = gsw_sa_from_sp(tracer_data_values_2(k, row), pres, Lon_degree(1), Lat_degree(1&
-                        ))
+                ! FIX OG: Pass length-1 array literals for scalar tracer values so all
+                !      GSW arguments are consistently rank-1 arrays of length 1.
+                sa = gsw_sa_from_sp(tracer_data_values_2(k, row), pres, Lon_degree(1), Lat_degree(1))
                 ct = gsw_ct_from_pt(sa, tracer_data_values_1(k, row))
                 rho_seawater = gsw_rho(sa, ct, pres)
 
-                ! (i.e. no density scaling)
-                scaling_density1_3D(k, row) = 1.0
-                scaling_density2_3D(k, row) = 1.0
+                ! Default: no density effect (neutral scaling)
+                scaling_density1_3D(k, row) = 1.0_WP
+                scaling_density2_3D(k, row) = 1.0_WP
 
                 if (use_density_scaling) then
                     !if (tracers%data(tr_num)%ID ==1008)then !idetc
                     !if (tracers%data(tr_num)%values(k,row)>0.001) then ! only apply ballasting
-                    !above a certain biomass (OG Todo: remove)
-                    scaling_density1_3D(k, row) = (rho_particle1(k, row) - rho_seawater(1)) &
-                            / (rho_ref_part - rho_ref_water)
+                    scaling_density1_3D(k, row) = &
+                        (rho_particle1(k, row) - rho_seawater(1)) / (rho_ref_part - rho_ref_water)
                     !endif
                     !endif
-                    !if (enable_3zoo2det .and. &
-                    !tracers%data(tr_num)%ID ==1026)then ! idetz2c
+                    if (enable_3zoo2det) &
                     !if (tracers%data(tr_num)%values(k,row)>0.001) then ! only apply ballasting
-                    !above a certain biomass (OG Todo: remove)
-                    scaling_density2_3D(k, row) = (rho_particle2(k, row) - rho_seawater(1)) &
-                            / (rho_ref_part - rho_ref_water)
+                    scaling_density2_3D(k, row) = &
+                        (rho_particle2(k, row) - rho_seawater(1)) / (rho_ref_part - rho_ref_water)
                     !endif
                     !endif
                 end if
 
                 scaling_visc_3D(k, row) = 1.0
-
-                if (use_viscosity_scaling) then
-                    if (seawater_visc_3D(k, row) < tiny) then
-                        scaling_visc_3D(k, row) = 1.0
-                    else
-                        scaling_visc_3D(k, row) = visc_ref_water / seawater_visc_3D(k, row)
-                    end if
+                if (use_viscosity_scaling .and. seawater_visc_3D(k, row) /= 0.0_WP) then
+                    scaling_visc_3D(k, row) = visc_ref_water / seawater_visc_3D(k, row)
                 end if
 
             end do
-            rho_particle1(nzmax + 1, row) = rho_particle1(nzmax, row)
-            rho_particle2(nzmax + 1, row) = rho_particle2(nzmax, row)
-            scaling_visc_3D(nzmax + 1, row) = scaling_visc_3D(nzmax, row)
+
+            ! Extend bottom values one level for flux-point access in ver_sinking_recom
+            ! FIXED OG:
+            scaling_density1_3D(nzmax+1, row)    = scaling_density1_3D(nzmax, row)
+            scaling_visc_3D(nzmax+1, row)  = scaling_visc_3D(nzmax, row)
+            if (enable_3zoo2det) then
+                scaling_density2_3D(nzmax+1, row) = scaling_density2_3D(nzmax, row)
+            end if
         end do
-        ! in the unlikely (if possible at all...) case that rho_particle(k)-rho_seawater(1)<0,
-        ! prevent the scaling factor from being negative
-
-        ! tiny = 2.23D-16
-        if (any(scaling_density1_3D(:, :) <= tiny)) scaling_density1_3D(:, :) = 1.0_WP
-
-        if (enable_3zoo2det) then
-            ! tiny = 2.23D-16
-            if (any(scaling_density2_3D(:, :) <= tiny)) scaling_density2_3D(:, :) = 1.0_WP
-        end if
 
     end subroutine ballast
 
-    !-------------------------------------------------------------------------------
-    ! Subroutine calculate density of particle
-    ! depending on composition (detC, detOpal, detCaCO3) based on Cram et al. (2018)
-    !-------------------------------------------------------------------------------
+!===============================================================================
+! get_particle_density
+!   Computes the bulk density of each detritus class from its elemental
+!   composition, following Cram et al. (2018).
+!
+!   rho_particle = rho_CaCO3 * f_cal + rho_opal * f_si
+!                + rho_POC   * f_c   + rho_PON  * f_n
+!
+!   where fractions f_x = component_x / sum(all components).
+!
+!===============================================================================
     subroutine get_particle_density(num_tracers, myDim_nod2d, eDim_nod2D, nl, ulevels_nod2D, &
             nlevels_nod2D, tracers_info)
 
@@ -887,7 +906,7 @@ contains
 
         do row = 1, myDim_nod2d
             nzmin = ulevels_nod2D(row)
-            nzmax = nlevels_nod2D(row)
+            nzmax = nlevels_nod2D(row) - 1 
             aux(nzmin:nzmax, row) = b1(nzmin:nzmax, row) + b2(nzmin:nzmax, row) &
                     + b3(nzmin:nzmax, row) + b4(nzmin:nzmax, row)
             a1(nzmin:nzmax, row) = b1(nzmin:nzmax, row) / aux(nzmin:nzmax, row)
@@ -926,9 +945,8 @@ contains
             end do
 
             do row = 1, myDim_nod2d + eDim_nod2D ! myDim is sufficient
-                !if (ulevels_nod2D(row)>1) cycle
                 nzmin = ulevels_nod2D(row)
-                nzmax = nlevels_nod2D(row)
+                nzmax = nlevels_nod2D(row) - 1
                 aux(nzmin:nzmax, row) = b1(nzmin:nzmax, row) + b2(nzmin:nzmax, row) &
                         + b3(nzmin:nzmax, row) + b4(nzmin:nzmax, row)
                 a1(nzmin:nzmax, row) = b1(nzmin:nzmax, row) / aux(nzmin:nzmax, row)
@@ -943,10 +961,19 @@ contains
 
     end subroutine get_particle_density
 
-    !-------------------------------------------------------------------------------
-    ! Subroutine to approximate seawater viscosity with current temperature
-    ! based on Cram et al. (2018)
-    !-------------------------------------------------------------------------------
+!===============================================================================
+! get_seawater_viscosity
+!   Approximates dynamic seawater viscosity [kg/(m<C2><B7>s)] as a function of
+!   temperature and salinity using Sharqawy et al. (2010).
+!
+!   Validity: T <E2><88><88> [0, 180] deg C,  S <E2><88><88> [0, 0.15] kg/kg.
+!   Salinity effects are secondary to temperature but included via the
+!   A/B correction terms; salinity is converted from practical units to
+!   kg/kg by multiplying by 0.001.
+!
+!   Cavity nodes are included <E2><80><94> viscosity affects sinking in sub-shelf
+!   waters too.
+!===============================================================================
 
     ! neglecting salinity effects, which are much smaller than those of temperature
     ! https://bitbucket.org/ohnoplus/ballasted-sinking/src/master/tools/waterviscosity.m
@@ -977,7 +1004,7 @@ contains
             ! OG Do we need any limitation here?
             ! i.e., if (seawater_visc_3D(row)<=0.0_WP) cycle
             nzmin = ulevels_nod2D(row)
-            nzmax = nlevels_nod2D(row)
+            nzmax = nlevels_nod2D(row) - 1
 
             do k = nzmin, nzmax
                 ! Eq from Sharaway 2010

--- a/recom_sms.F90
+++ b/recom_sms.F90
@@ -8,7 +8,7 @@ module recom_sms_module
 
 contains
 
-    subroutine REcoM_sms(n, Nn, state, thick, SurfSR, sms, Temp, Sali_depth, CO2_watercolumn, &
+    subroutine REcoM_sms(n, nzmin, Nn, state, thick, SurfSR, sms, Temp, Sali_depth, CO2_watercolumn, &
             pH_watercolumn, pCO2_watercolumn, HCO3_watercolumn, CO3_watercolumn, &
             OmegaC_watercolumn, kspc_watercolumn, rhoSW_watercolumn, Loc_slp, &
             zF, PAR, Latd, daynew, dt, kappa, mstep, MPI_COMM_FESOM, mype, &
@@ -125,6 +125,7 @@ contains
         integer, intent(in) :: n, daynew, mype, myDim_nod2D, eDim_nod2D, nl, mstep
         integer, intent(in) :: MPI_COMM_FESOM
         integer, intent(in) :: Nn !< Total number of nodes in the vertical
+        integer, intent(in) :: nzmin
 
         real(kind=wp), intent(in) :: SurfSR, dt !< [W/m2] ShortWave radiation at surface
         real(kind=wp), intent(in) :: Loc_slp ![Pa] sea-level pressure
@@ -468,14 +469,15 @@ contains
             !   - myDim_nod2D: Horizontal dimension (for 3D unstructured grids)
             !---------------------------------------------------------------------------
 
-            do k = one, nn
+            !do k = one, nn
+            do k = nzmin, nn
                 ! Alternative loop structures (commented out):
                 ! do n = 1, myDim_nod2D
                 !     Nn = nlevels_nod2D(n) - 1
                 !     nzmin = ulevels_nod2D(row)
                 !     nzmax = nlevels_nod2D(row)
 
-                call sms_initialize_variables(n, k, state, sms, thick, Temp, Sali_depth, SurfSR, &
+                call sms_initialize_variables(n, nzmin, k, state, sms, thick, Temp, Sali_depth, SurfSR, &
                         PAR, kappa, DIN, DIC, Alk, PhyN, PhyC, PhyChl, DetN, DetC, HetN, HetC, &
                         DON, EOC, DiaN, DiaC, DiaChl, DiaSi, DetSi, Si, Fe, PhyCalc, DetCalc, &
                         FreeFe, O2, DICremin, CoccoN, CoccoC, CoccoChl, PhaeoN, PhaeoC, PhaeoChl, Zoo2N, &

--- a/recom_sms_init.F90
+++ b/recom_sms_init.F90
@@ -5,7 +5,7 @@ module recom_sms_init
 
 contains
 
-    subroutine sms_initialize_variables(n, k, state, sms, thick, Temp, Sali_depth, SurfSR, PAR, &
+    subroutine sms_initialize_variables(n, nzmin, k, state, sms, thick, Temp, Sali_depth, SurfSR, PAR, &
             kappa, DIN, DIC, Alk, PhyN, PhyC, PhyChl, DetN, DetC, HetN, HetC, DON, EOC, DiaN, &
             DiaC, DiaChl, DiaSi, DetSi, Si, Fe, PhyCalc, DetCalc, FreeFe, O2, DICremin, CoccoN, CoccoC, &
             CoccoChl, PhaeoN, PhaeoC, PhaeoChl, Zoo2N, Zoo2C, DetZ2N, DetZ2C, DetZ2Si, DetZ2Calc, &
@@ -47,7 +47,7 @@ contains
 
         implicit none
 
-        integer, intent(in) :: n, k
+        integer, intent(in) :: n, nzmin, k
 
         real(kind=wp), intent(in) :: SurfSR
         real(kind=wp), intent(in), dimension(:) :: thick, Temp, Sali_depth
@@ -960,7 +960,8 @@ contains
         !   - Self-shading is key negative feedback on bloom magnitude
         !-------------------------------------------------------------------------------
 
-        if (k == 1) then
+        !if (k == 1) then ! OG: Under the ice shelf set SurfSR = 0.0_WP. for consistency, I keep it as nzmin.
+        if (k == nzmin) then
 
             !===========================================================================
             ! SURFACE LAYER INITIALIZATION

--- a/recom_sms_update.F90
+++ b/recom_sms_update.F90
@@ -7,7 +7,7 @@ module recom_sms_update
 
 contains
 
-    subroutine sms_update_tracer_scalars(n, k, state, sms, thick, Temp, Sali_depth, SurfSR, PAR, &
+    subroutine sms_update_tracer_scalars(n, nzmin, k, state, sms, thick, Temp, Sali_depth, SurfSR, PAR, &
             kappa, DIN, DIC, Alk, PhyN, PhyC, PhyChl, DetN, DetC, HetN, HetC, DON, EOC, DiaN, &
             DiaC, DiaChl, DiaSi, DetSi, Si, Fe, PhyCalc, DetCalc, FreeFe, O2, DICremin, CoccoN, CoccoC, &
             CoccoChl, PhaeoN, PhaeoC, PhaeoChl, Zoo2N, Zoo2C, DetZ2N, DetZ2C, DetZ2Si, DetZ2Calc, &
@@ -49,7 +49,7 @@ contains
 
         implicit none
 
-        integer, intent(in) :: n, k
+        integer, intent(in) :: n, nzmin, k
 
         real(kind=wp), intent(in) :: SurfSR
         real(kind=wp), intent(in), dimension(:) :: thick, Temp, Sali_depth
@@ -961,8 +961,8 @@ contains
         !   - Self-shading is key negative feedback on bloom magnitude
         !-------------------------------------------------------------------------------
 
-        if (k == 1) then
-
+        !if (k == 1) then
+        if (k == nzmin) then
             !===========================================================================
             ! SURFACE LAYER INITIALIZATION
             !===========================================================================


### PR DESCRIPTION
…-shelf cavities

Introduce a top active vertical level (nzmin) throughout the REcoM forcing and sources-minus-sinks pipeline so that columns beneath ice-shelf cavities (nzmin > 1) are handled correctly instead of implicitly assuming a surface at level 1.

- REcoM_Forcing: accept nzmin; zero out CO2/O2 surface fluxes and related mocsy/DISS diagnostics for cavity nodes while leaving subsurface BGC unaffected; replace hardcoded level-1/nn bounds with nzmin:nn throughout (state clipping, ciso isotope updates, diagnostic vertical integrals); add descriptive comments and tightened DIC/CO2-flux sanity checks.
- Depth_calculations: accept nzmin; zero-initialize output arrays and restrict thickness, reciprocal-thickness, flux-depth, and sinking-velocity computations to the active range [nzmin, nzmax], with wF boundary set at nzmin instead of level 1.
- bio_fluxes / REcoM main driver: guard alkalinity relaxation, shortwave penetration, dust/N deposition, and tracer-array slicing behind ulevels_nod2D/nzmin checks; loop over nodes when resetting DICremin at the true (possibly sub-surface) surface level; pass nzmin into REcoM_Forcing and carbonate-chemistry array updates.
- ver_sinking_recom_benthos: skip cavity nodes (ulevels_nod2D > 1) since there is no water column above the ice-shelf base to deposit onto benthos.
- ballast / get_particle_density / get_seawater_viscosity: fix nzmax to consistently mean the last valid layer-center index (nlevels_nod2D - 1) rather than the interface count; pass length-1 arrays to depth2press and GSW routines for interface consistency; extend density/viscosity scaling arrays one level down for flux-point access.
- sms_initialize_variables / sms_update_tracer_scalars: accept nzmin and use it instead of a hardcoded k == 1 check to identify the surface layer.

Fix additional pre-existing issues surfaced alongside this change:
- Remove a duplicated `locgrazmacro_c` entry in a use statement and a duplicated `co2flux` entry in another.
- Fix an operator-precedence bug in the second-detritus sinking-speed condition (missing parentheses around the OR chain).
- Correct bottom_flux normalization in ver_sinking_recom_benthos to divide by areasvol(ul1,:) instead of area(1,:).